### PR TITLE
[#1651] Fixed spelling error

### DIFF
--- a/scripts/xnat/check_phantom_scans
+++ b/scripts/xnat/check_phantom_scans
@@ -178,7 +178,7 @@ def check_experiment(experiment):
             elif len(phantom_scans) == 0:
                 find_phantom_scan_24h(prj, experiment_label, seid, experiment_last_modified, phantom_id, edate, etime, scanner)
         except IndexError, e:
-            error="ERROR: Subject likely swithced sites. {}".format(e)
+            error="ERROR: Subject likely switched sites. {}".format(e)
             sibis.logging(experiment_label,error,
                          site_id=sid,
                          project=prj,


### PR DESCRIPTION
Test procedure to resolve the bug:
- run command: ./check_phantom_scans -e NCANDA_E05653 -v
- original error:
{"error": "ERROR: Subject likely swithced sites. list index out of range", "experiment_site_id": "E-00084-F-7-20160628", "project": "sri_incoming", "site_id": "NCANDA_S01035", "subject_experiment_id": "NCANDA_E05653"}
- final error:
{"error": "ERROR: Subject likely switched sites. list index out of range", "experiment_site_id": "E-00084-F-7-20160628", "project": "sri_incoming", "site_id": "NCANDA_S01035", "subject_experiment_id": "NCANDA_E05653"}


