### PR TITLE
Sort on list of strings for grefieldmap

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -412,7 +412,7 @@ frame_check_siemens = {'ncanda-mprage-v1': '160',
                        'ncanda-t2fse-v1': '160',
                        'ncanda-dti6b500pepolar-v1': '7',
                        'ncanda-dti60b1000-v1': '62',
-                       'ncanda-grefieldmap-v1': ['128', '64'],
+                       'ncanda-grefieldmap-v1': ['64', '128'],
                        'ncanda-rsfmri-v1': '275'}
 
 frame_check_ge = {'ncanda-t1spgr-v1': '146',
@@ -421,7 +421,6 @@ frame_check_ge = {'ncanda-t1spgr-v1': '146',
                   'ncanda-dti60b1000-v1': '3968',
                   'ncanda-grefieldmap-v1': '384',
                   'ncanda-rsfmri-v1': '8768'}
-
 
 def frame_check(eid, manufacturer, label):
     scan_id = 'xnat:mrSessionData/scans/scan/id'
@@ -443,7 +442,8 @@ def frame_check(eid, manufacturer, label):
         # Variable frames has two grefieldmap keys, change to one key and list of values.
         # Extract values list -> ['64', '128']
         grefieldmap_list = ['ncanda-grefieldmap-v1', [v for (k, v) in frames if k == 'ncanda-grefieldmap-v1']]
-
+        # Sort number of frames for later comparison
+        grefieldmap_list[1].sort(lambda x, y: int(x) - int(y))
         # Change all frames with fixed grefieldmap
         frames = filter(lambda x: x[0] != 'ncanda-grefieldmap-v1', frames) + [grefieldmap_list]
 


### PR DESCRIPTION
Changes for Issue:
https://github.com/sibis-platform/ncanda-operations/issues/1965

Tested it on 
```bash
(ncanda-dev)[frontal03] /fs/data13/sbenito/ncanda-data-integration/scripts > ./xnat/check_new_sessions -v -e NCANDA_E05960
Script was last run 2016-09-21 22:29:19.559
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-09-21 22:29:19
Checking a total of 1 experiments
Checking experiment upmc_incoming/A-00029-F-7-20160829 SID:NCANDA_S00179 EID:NCANDA_E05960, insert date 2016-08-29 08:00:41.885, modified date 2016-09-08 09:15:08.47599...Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Beginning QC...RECHECK
<b>Summary</b>
<ol>
<li>Sessions with Questionable Scans: <a href="#questionable">&nbsp;1&nbsp;</a></li>
</ol>
<b><a id="questionable">Sessions with Questionable Scans</a></b>
<ol><li><a href=https://ncanda.sri.com/xnat/app/action/DisplayItemAction/search_value/NCANDA_E05960/search_element/xnat:mrSessionData/search_field/xnat:mrSessionData.ID/project/upmc_incoming>upmc_incoming/NCANDA_E05960/A-00029-F-7-20160829</a></li>
/fs/ncanda-xnat/archive/upmc_incoming/arc001/A-00029-F-7-20160829/RESOURCES/nifti<BR>
ncanda-grefieldmap-v1</ol>


```
