### PR TITLE
[#1989] Resolved sort in frames for dti60

### DIFF
--- a/scripts/xnat/check_gradient_tables.py
+++ b/scripts/xnat/check_gradient_tables.py
@@ -100,6 +100,7 @@ def get_all_gradients(session_label, dti_stack, decimals=None):
         try:
             gradients_per_frame.append(get_gradient_table(xml_sidecar,
                                                      decimals=decimals))
+            gradients_as_array = np.asanyarray(gradients_per_frame)
         except Exception as e:
             sibis.logging(session_label,
                           'ERROR: Could not get gradient table from xml sidecar',
@@ -107,7 +108,7 @@ def get_all_gradients(session_label, dti_stack, decimals=None):
                           sidecar=str(xml_sidecar),
                           xml_path=xml_path,
                           error=str(e))
-    return gradients_per_frame
+    return gradients_as_array
 
 
 def get_site_scanner(site):


### PR DESCRIPTION
Related to Issue:
[#1989](https://github.com/sibis-platform/ncanda-operations/issues/1989)
Finally, I decided not to move code to another module. The sort() problem was resolved once both arrays where numpy objects.
I agree in make_session_nifits there is code that does not correspond there and needs to be moved. Let me think about the better way to do so.
