### PR TITLE
Iss 2113

### DIFF
--- a/scripts/crond/post_github_issues.py
+++ b/scripts/crond/post_github_issues.py
@@ -213,8 +213,9 @@ def create_issues(repo, title, body, verbose=None):
                 print 'Title: ', subject
                 print 'Body: ', body
                 print 'Exception: ', str(e)
-            if verbose:
-                print "Created issue... See: {0}".format(github_issue.url)
+            else:
+                if verbose:
+                    print "Created issue... See: {0}".format(github_issue.url)
     return None
 
 

--- a/scripts/crond/post_github_issues.py
+++ b/scripts/crond/post_github_issues.py
@@ -208,8 +208,11 @@ def create_issues(repo, title, body, verbose=None):
             try:
                 github_issue = repo.create_issue(subject, body=body, labels=label)
             except Exception as e:
-                print 'Failed to create_issue with title:{0}, body:{1} and label:{2}, \
-                       exception: {3}'.format(subject, body, label, str(e))
+                print '====================================='
+                print 'Error:post_github_issues: Failed to post the following issue on github'
+                print 'Title: ', subject
+                print 'Body: ', body
+                print 'Exception: ', str(e)
             if verbose:
                 print "Created issue... See: {0}".format(github_issue.url)
     return None

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -650,8 +650,9 @@ for [key, row] in mr_sessions_redcap.iterrows():
                    import_response = redcap_project.import_records( [record], overwrite='overwrite' )
 
                 except requests.exceptions.RequestException as e:
-                    error = 'Failed to import xnat data into redcap. Dictionary with xnat_data: ', record
+                    error = 'Failed to import xnat data into redcap'
                     sibis.logging(record["mri_xnat_eids"], error,
+                                  xnat_data_dictionary=str(record),
                                   mri_xnat_sid=record["mri_xnat_sid"],
                                   requestError=str(e))
                     continue


### PR DESCRIPTION
@kipohl 
a) Changed code in post_github_issues
print '====================================='
print 'Error:post_github_issues: Failed to post the following issue on github'
print ' Title:' + ...
print ' Body:' + ....

b) Replicate this failure:
```bash
(ncanda-dev)[frontal03] /fs/data13/sbenito/ncanda-data-integration > python scripts/crond/post_github_issues.py --org sibis-platform --repo ncanda-operations --title "NCANDA Pipeline Feeder Messages (import_mr_sessions)" --body /tmp/sbenito/body.txt -v
Initializing...
Parsing config: /fs/u00/sbenito/.server_config/github.cfg
Connected to GitHub...
Checking for open issue: NCANDA_E02268, [u'Failed to import xnat data into redcap. Dictionary with xnat_data: ', {u'mri_inspection___completed': 0.0, u'mri_findingsdate': u'2014-08-24', u'mri_adni_phantom': u'1', u'mri_findings': u'NORMAL; see Notes', u'visit_ignore___yes': 0.0, u'mri_xnat_sid': u'NCANDA_S00310', u'mri_eid_spiral_stroop': u'', u'mri_adni_phantom_eid': u'NCANDA_E02269', u'mri_series_rsfmri': u'NCANDA_E02268/14', u'mri_series_t1': u'NCANDA_E02268/3', u'mri_series_t2': u'NCANDA_E02268/2', u'mri_qa_completed': u'0', u'mri_series_dti60b1000': u'NCANDA_E02268/6', u'mr_session_report_complete': u'1', u'mri_datetodvd': u'2014-07-27', u'mri_rsfmri_age': u'14.217970551', u'mri_series_dti_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_dti_age': u'14.217970551', u'mri_t1_date': u'2014-07-24', u'mri_series_rsfmri_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_series_dti6b500pepolar': u'NCANDA_E2269/4', u'redcap_event_name': u'1y_visit_arm_1', u'mri_excludefromanalysis': u'', u'mri_dti!_date': u'2014-07-24', u'mri_referredtopi': u'', u'mri_t1_age': u'14.217970551', u'mri_xnat_eids': u'NCANDA_E02268', u'study_id': u'A-00042-F-2', u'visit_date': u'2014-07-24', u'mri_eid_spiral_rest': u'', u'mri_rsfmri_date': u'2014-07-24', u'mri_notes': u'[NCANDA_E02268] Incidental sinus retention cysts, right max. & sphenoid sinuses.'}]
Issue does not already exist... Creating.
=====================================
Error:post_github_issues: Failed to post the following issue on github
Title:  NCANDA_E02268, [u'Failed to import xnat data into redcap. Dictionary with xnat_data: ', {u'mri_inspection___completed': 0.0, u'mri_findingsdate': u'2014-08-24', u'mri_adni_phantom': u'1', u'mri_findings': u'NORMAL; see Notes', u'visit_ignore___yes': 0.0, u'mri_xnat_sid': u'NCANDA_S00310', u'mri_eid_spiral_stroop': u'', u'mri_adni_phantom_eid': u'NCANDA_E02269', u'mri_series_rsfmri': u'NCANDA_E02268/14', u'mri_series_t1': u'NCANDA_E02268/3', u'mri_series_t2': u'NCANDA_E02268/2', u'mri_qa_completed': u'0', u'mri_series_dti60b1000': u'NCANDA_E02268/6', u'mr_session_report_complete': u'1', u'mri_datetodvd': u'2014-07-27', u'mri_rsfmri_age': u'14.217970551', u'mri_series_dti_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_dti_age': u'14.217970551', u'mri_t1_date': u'2014-07-24', u'mri_series_rsfmri_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_series_dti6b500pepolar': u'NCANDA_E2269/4', u'redcap_event_name': u'1y_visit_arm_1', u'mri_excludefromanalysis': u'', u'mri_dti!_date': u'2014-07-24', u'mri_referredtopi': u'', u'mri_t1_age': u'14.217970551', u'mri_xnat_eids': u'NCANDA_E02268', u'study_id': u'A-00042-F-2', u'visit_date': u'2014-07-24', u'mri_eid_spiral_rest': u'', u'mri_rsfmri_date': u'2014-07-24', u'mri_notes': u'[NCANDA_E02268] Incidental sinus retention cysts, right max. & sphenoid sinuses.'}]
Body:  ### NCANDA Pipeline Feeder Messages (import_mr_sessions)
- experiment_site_id: NCANDA_E02268
- error: [u'Failed to import xnat data into redcap. Dictionary with xnat_data: ', {u'mri_inspection___completed': 0.0, u'mri_findingsdate': u'2014-08-24', u'mri_adni_phantom': u'1', u'mri_findings': u'NORMAL; see Notes', u'visit_ignore___yes': 0.0, u'mri_xnat_sid': u'NCANDA_S00310', u'mri_eid_spiral_stroop': u'', u'mri_adni_phantom_eid': u'NCANDA_E02269', u'mri_series_rsfmri': u'NCANDA_E02268/14', u'mri_series_t1': u'NCANDA_E02268/3', u'mri_series_t2': u'NCANDA_E02268/2', u'mri_qa_completed': u'0', u'mri_series_dti60b1000': u'NCANDA_E02268/6', u'mr_session_report_complete': u'1', u'mri_datetodvd': u'2014-07-27', u'mri_rsfmri_age': u'14.217970551', u'mri_series_dti_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_dti_age': u'14.217970551', u'mri_t1_date': u'2014-07-24', u'mri_series_rsfmri_fieldmap': u'NCANDA_E02268/12 NCANDA_E02268/13', u'mri_series_dti6b500pepolar': u'NCANDA_E2269/4', u'redcap_event_name': u'1y_visit_arm_1', u'mri_excludefromanalysis': u'', u'mri_dti!_date': u'2014-07-24', u'mri_referredtopi': u'', u'mri_t1_age': u'14.217970551', u'mri_xnat_eids': u'NCANDA_E02268', u'study_id': u'A-00042-F-2', u'visit_date': u'2014-07-24', u'mri_eid_spiral_rest': u'', u'mri_rsfmri_date': u'2014-07-24', u'mri_notes': u'[NCANDA_E02268] Incidental sinus retention cysts, right max. & sphenoid sinuses.'}]

Exception:  422 {u'documentation_url': u'https://developer.github.com/v3/issues/#create-an-issue', u'message': u'Validation Failed', u'errors': [{u'field': u'title', u'message': u'title is too long (maximum is 256 characters)', u'code': u'custom', u'resource': u'Issue'}]}
Finished!
```
c) fix it:
Changed code in import_mr_sessions so error does not add dictionary with data from XNat


