### PR TITLE
[#2088] Changed warning message in make_session_niftis

### DIFF
--- a/scripts/xnat/make_session_niftis.py
+++ b/scripts/xnat/make_session_niftis.py
@@ -45,13 +45,14 @@ def verify_image_count(session, session_label, scan, scantype, manufacturer,
         if scantype in expected_images[manufacturer].keys():
             imgrange = expected_images[manufacturer][scantype]
             if not images_created in imgrange:
-                error = 'WARNING: Scan found more images than expected.'
+                error = 'WARNING: Number of niftis in archive differ from the standard'
                 sibis.logging(session_label, error,
                               session=session,
-                              scan=scan,
+                              scan_number=scan,
                               scan_type=scantype,
-                              images_created=images_created,
-                              expected_images=expected_images)
+                              niftis_checked=images_created,
+                              manufacturer=manufacturer,
+                              expected_number_niftis=str(expected_images[manufacturer][scantype]))
 
 
 #

--- a/scripts/xnat/make_session_niftis.py
+++ b/scripts/xnat/make_session_niftis.py
@@ -45,14 +45,14 @@ def verify_image_count(session, session_label, scan, scantype, manufacturer,
         if scantype in expected_images[manufacturer].keys():
             imgrange = expected_images[manufacturer][scantype]
             if not images_created in imgrange:
-                error = 'WARNING: Number of niftis in archive differ from the standard'
+                error = 'WARNING: Number of frames in archive differ from the standard'
                 sibis.logging(session_label, error,
                               session=session,
                               scan_number=scan,
                               scan_type=scantype,
-                              niftis_checked=images_created,
+                              actual_frame_number=images_created,
                               manufacturer=manufacturer,
-                              expected_number_niftis=str(expected_images[manufacturer][scantype]))
+                              expected_frame_number=str(expected_images[manufacturer][scantype]))
 
 
 #


### PR DESCRIPTION
@kipohl 
#Tested running scripts/xnat/check_new_sessions, modifying the code so the niftis are only stored in temporary file, like this:
https://gist.github.com/sbenito/2ca55c486cd17441a3832db524fc9859
Run test in local ncanda-dev:
```bash
(ncanda-dev)[frontal03] /fs/data13/sbenito/ncanda-data-integration > ./scripts/xnat/check_new_sessions -e NCANDA_E06006 -v
Script was last run 2016-11-05 22:28:08.934
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-11-05 22:28:08
Checking a total of 1 experiments
Checking experiment ohsu_incoming/D-00144-F-2-20160901 SID:NCANDA_S00403 EID:NCANDA_E06006, insert date 2016-09-06 08:49:00.639, modified date 2016-11-01 22:58:02.209431...Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
Starting export of nifti files...
{"error": "WARNING: Number of niftis in archive differ from the standard", "expected_number_niftis": "[7]", "experiment_site_id": "D-00144-F-2-20160901", "manufacturer": "SIEMENS", "niftis_checked": 8, "scan_number": "4", "scan_type": "ncanda-dti6b500pepolar-v1", "session": "NCANDA_E06006"}
Starting export of nifti files...
```