### PR TITLE
Iss-2351

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -424,7 +424,7 @@ def voxelRes_check(eid, manufacturer, label):
                     error.append({'field': 'Voxel Resolution',
                                   'scan_type': v[0],
                                   'voxel_res': v[1],
-                                  'expected_voxel_res': voxelres_siemens[v[0]]})
+                                  'expected_voxel_res': voxelres_ge[v[0]]})
     elif manufacturer == 'SIEMENS':
         for v in voxel_res:
             if v[0] in scan_type_dictionary['SIEMENS']:


### PR DESCRIPTION
@kipohl 
[issues/2351](https://github.com/sibis-platform/ncanda-operations/issues/2351)
Error did not show the appropriate voxel resolution. 
Replicated on ncanda-storage:
```bash
[torsten@ncanda-storage scripts]$ ./xnat/check_new_sessions --eid NCANDA_E00768 -v
Script was last run 2016-11-15 23:26:34.927
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-11-15 23:26:34
Checking a total of 1 experiments
Checking experiment duke_incoming/C-70054-M-7-20130813 SID:NCANDA_S00394 EID:NCANDA_E00768, insert date 2013-08-22 12:19:44.946, modified date 2016-04-01 15:04:40.7855...Starting export of nifti files for  duke_incoming NCANDA_S00394 NCANDA_E00768 C-70054-M-7-20130813 1 ncanda-localizer-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  duke_incoming NCANDA_S00394 NCANDA_E00768 C-70054-M-7-20130813 3 ncanda-t2fse-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  duke_incoming NCANDA_S00394 NCANDA_E00768 C-70054-M-7-20130813 4 ncanda-t1spgr-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  duke_incoming NCANDA_S00394 NCANDA_E00768 C-70054-M-7-20130813 6 ncanda-dti6b500pepolar-v1
... nothing to do as nifti files are up to date