### PR TITLE
Check if ncanda-grefieldmap-v1 is present before pass frame check

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -490,14 +490,6 @@ def frame_check(eid, manufacturer, label):
                                   'expected_frames': frame_check_ge[f[0]],
                                   'scan_id': scan})
     elif manufacturer == 'SIEMENS':
-        # Variable frames has two grefieldmap keys, change to one key and list of values.
-        # Extract values list -> ['64', '128']
-        grefieldmap_list = ['ncanda-grefieldmap-v1', [v for (k, v) in frames if k == 'ncanda-grefieldmap-v1']]
-        # Sort number of frames for later comparison
-        grefieldmap_list[1].sort(lambda x, y: int(x) - int(y))
-        # Change all frames with fixed grefieldmap
-        frames = filter(lambda x: x[0] != 'ncanda-grefieldmap-v1', frames) + [grefieldmap_list]
-
         for f in frames:
             if f[0] not in scan_type_dictionary['SIEMENS']:
                 continue 
@@ -508,6 +500,14 @@ def frame_check(eid, manufacturer, label):
                                   'frames': f[1],
                                   'expected_frames': frame_check_siemens[f[0]],
                                   'scan_id': scan})
+            elif f[0] == 'ncanda-grefieldmap-v1':
+                # Variable frames has two grefieldmap keys, change to one key and list of values.
+                # Extract values list -> ['64', '128']
+                grefieldmap_list = ['ncanda-grefieldmap-v1', [v for (k, v) in frames if k == 'ncanda-grefieldmap-v1']]
+                # Sort number of frames for later comparison
+                grefieldmap_list[1].sort(lambda x, y: int(x) - int(y))
+                # Change all frames with fixed grefieldmap
+                frames = filter(lambda x: x[0] != 'ncanda-grefieldmap-v1', frames) + [grefieldmap_list]
             elif f[1] != frame_check_siemens[f[0]]:
                 # Some of the required frames are missing
                 error.append({'scan_type': f[0],


### PR DESCRIPTION
@kipohl 
https://github.com/sibis-platform/ncanda-operations/issues/2363
Error replicated on ncanda-storage
```bash
./scripts/xnat/check_new_sessions -v --eid NCANDA_E00424
Script was last run 2016-11-15 23:26:34.927
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-11-15 23:26:34
Checking a total of 1 experiments
All sessions: [('NCANDA_E00424', 'upmc_incoming', 'NCANDA_S00234', '2013-06-13 14:01:30.064', 'A-00033-M-7-20130613-1', '2016-11-20 13:42:56.071367')]
Checking experiment upmc_incoming/A-00033-M-7-20130613-1 SID:NCANDA_S00234 EID:NCANDA_E00424, insert date 2013-06-13 14:01:30.064, modified date 2016-11-20 13:42:56.071367...Starting export of nifti files for  upmc_incoming NCANDA_S00234 NCANDA_E00424 A-00033-M-7-20130613-1 1 ncanda-localizer-v1
... nothing to do as nifti files are up to date
Beginning QC...A-00033-M-7-20130613-1 : All missing scans are excepted!
{"error": "ERROR: Failed to match standard frames", "experiment_site_id": "NCANDA_E00424", "scan_session_label": "A-00033-M-7-20130613-1", "violations": [{"expected_frames": ["64", "128"], "frames": [], "scan_id": "3", "scan_type": "ncanda-grefieldmap-v1"}]}
OK
```
Session has no ncanda-grefieldmap, and it is added to special_cases.yml
Moved code into elif statement, re-run script:
```bash
 ./scripts/xnat/check_new_sessions --eid NCANDA_E00424 -v
/usr/local/tools/miniconda/envs/ncanda-staging/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.
  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
Script was last run 2016-11-15 23:26:34.927
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-11-15 23:26:34
Checking a total of 1 experiments
Checking experiment upmc_incoming/A-00033-M-7-20130613-1 SID:NCANDA_S00234 EID:NCANDA_E00424, insert date 2013-06-13 14:01:30.064, modified date 2016-11-20 13:53:17.661373...Starting export of nifti files for  upmc_incoming NCANDA_S00234 NCANDA_E00424 A-00033-M-7-20130613-1 1 ncanda-localizer-v1
... nothing to do as nifti files are up to date
Beginning QC...A-00033-M-7-20130613-1 : All missing scans are excepted!
OK

```

