### PR TITLE
Changed code to observe dicoms that have no '.dcm'

### DIFF
--- a/scripts/xnat/make_session_niftis.py
+++ b/scripts/xnat/make_session_niftis.py
@@ -90,7 +90,8 @@ def export_to_nifti(interface, project, subject, session, session_label,
             # if nifti files were created make sure that they are newer than dicom file otherwise recreate them  
             nifti_log_search = glob.glob(re.sub('/DICOM/','_%s/dcm2image.log' % (scantype),re.sub( '/SCANS/', '/RESOURCES/nifti/', dicom_path)))
             if  nifti_log_search != [] :
-                # We load all files under dicom_path
+                # we changed code here from . to avoid getting errors of not finding dicom files for sessions such as
+                # NCANDA_E01386 / B-00454-M-9-20140214 - scan 1 /ncanda-localizer-v1
                 dicom_file_pattern = dicom_path + '*'
                 dicom_file_list = glob.glob(dicom_file_pattern)
                 # ommit xml file - so that only dicom  files are left - xml file is updated every time somebody changes something in the gui for that session - which has no meaning for xml file 

--- a/scripts/xnat/make_session_niftis.py
+++ b/scripts/xnat/make_session_niftis.py
@@ -90,7 +90,7 @@ def export_to_nifti(interface, project, subject, session, session_label,
             # if nifti files were created make sure that they are newer than dicom file otherwise recreate them  
             nifti_log_search = glob.glob(re.sub('/DICOM/','_%s/dcm2image.log' % (scantype),re.sub( '/SCANS/', '/RESOURCES/nifti/', dicom_path)))
             if  nifti_log_search != [] :
-                # we changed code here from . to avoid getting errors of not finding dicom files for sessions such as
+                # we changed code here from *.* to avoid getting errors of not finding dicom files for sessions such as
                 # NCANDA_E01386 / B-00454-M-9-20140214 - scan 1 /ncanda-localizer-v1
                 dicom_file_pattern = dicom_path + '*'
                 dicom_file_list = glob.glob(dicom_file_pattern)

--- a/scripts/xnat/make_session_niftis.py
+++ b/scripts/xnat/make_session_niftis.py
@@ -90,7 +90,8 @@ def export_to_nifti(interface, project, subject, session, session_label,
             # if nifti files were created make sure that they are newer than dicom file otherwise recreate them  
             nifti_log_search = glob.glob(re.sub('/DICOM/','_%s/dcm2image.log' % (scantype),re.sub( '/SCANS/', '/RESOURCES/nifti/', dicom_path)))
             if  nifti_log_search != [] :
-                dicom_file_pattern = dicom_path + '*.*'
+                # We load all files under dicom_path
+                dicom_file_pattern = dicom_path + '*'
                 dicom_file_list = glob.glob(dicom_file_pattern)
                 # ommit xml file - so that only dicom  files are left - xml file is updated every time somebody changes something in the gui for that session - which has no meaning for xml file 
                 dicom_file_list =  [x for x in dicom_file_list if '.xml' not in x ]


### PR DESCRIPTION
@kipohl 
https://github.com/sibis-platform/ncanda-operations/issues/2404
Replicated on ncanda-storage:
```bash
./scripts/xnat/check_new_sessions -e NCANDA_E01386 -v
Script was last run 2016-12-08 22:50:12.174
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-12-08 22:50:12
Checking a total of 1 experiments
Checking experiment sri_incoming/B-00454-M-9-20140214 SID:NCANDA_S00670 EID:NCANDA_E01386, insert date 2014-03-03 10:35:12.531, modified date 2014-08-27 13:29:11.186268...
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 1 ncanda-localizer-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/1/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "1", "scan_type": "ncanda-localizer-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 2 ncanda-calibration-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/2/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "2", "scan_type": "ncanda-calibration-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 3 ncanda-t2fse-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/3/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "3", "scan_type": "ncanda-t2fse-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 4 ncanda-t1spgr-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/4/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "4", "scan_type": "ncanda-t1spgr-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 6 ncanda-dti6b500pepolar-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/6/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "6", "scan_type": "ncanda-dti6b500pepolar-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 7 ncanda-dti60b1000-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/7/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "7", "scan_type": "ncanda-dti60b1000-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 8 ncanda-grefieldmap-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/8/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "8", "scan_type": "ncanda-grefieldmap-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 9 ncanda-rsfmri-v1
{"dicom_log_file": "/fs/ncanda-xnat/archive/sri_incoming/arc001/B-00454-M-9-20140214/SCANS/9/DICOM/*.*", "error": "Error: could not find dicom files ", "experiment_site_id": "B-00454-M-9-20140214", "scan_number": "9", "scan_type": "ncanda-rsfmri-v1", "session": "NCANDA_E01386", "subject": "NCANDA_S00670"}
Beginning QC...OK
```
Changes proposed have worked, run on ncanda-storage:
```bash
./scripts/xnat/check_new_sessions -e NCANDA_E01386 -v
Script was last run 2016-12-08 22:50:12.174
Re-checking 1 previously flagged experiments
Checking sessions modified after 2016-12-08 22:50:12
Checking a total of 1 experiments
Checking experiment sri_incoming/B-00454-M-9-20140214 SID:NCANDA_S00670 EID:NCANDA_E01386, insert date 2014-03-03 10:35:12.531, modified date 2014-08-27 13:29:11.186268...
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 1 ncanda-localizer-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 2 ncanda-calibration-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 3 ncanda-t2fse-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 4 ncanda-t1spgr-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 6 ncanda-dti6b500pepolar-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 7 ncanda-dti60b1000-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 8 ncanda-grefieldmap-v1
... nothing to do as nifti files are up to date
Starting export of nifti files for  sri_incoming NCANDA_S00670 NCANDA_E01386 B-00454-M-9-20140214 9 ncanda-rsfmri-v1
... nothing to do as nifti files are up to date
Beginning QC...OK
```