### PR TITLE
[#175] If args.study_id is given only export this record

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -180,15 +180,14 @@ entry_data_fields = [('%s_complete' % form) for form in form_names] + [('%s_miss
 entry_data_fields += ['study_id', 'dob', 'redcap_event_name', 'visit_date', 'exclude', 'sleep_date']
 
 # Get list of existing records
-entry_data = rc_entry.export_records(fields=entry_data_fields,
+if args.study_id:
+    entry_data = rc_entry.export_records(records=[args.study_id], fields=entry_data_fields,
                                           event_name='unique',
                                           format='df')
-
-if args.study_id : 
-    entry_data = entry_data.xs(args.study_id)
-    entry_data.reset_index(inplace=True)
-    entry_data['study_id'] = args.study_id
-    entry_data.set_index(['study_id', 'redcap_event_name'],inplace=True)
+else:
+    entry_data = rc_entry.export_records(fields=entry_data_fields,
+                                          event_name='unique',
+                                          format='df')
 
 # Save dates of birth for later (these only exist for the 'baseline_visit_arm_1'
 # event, but we need them for other arms as well


### PR DESCRIPTION
@kipohl 

Old logic:
```python
# Get list of existing records
entry_data = rc_entry.export_records(fields=entry_data_fields,
                                          event_name='unique',
                                          format='df')

if args.study_id :
    entry_data = entry_data.xs(args.study_id)
    entry_data.reset_index(inplace=True)
    entry_data['study_id'] = args.study_id
    entry_data.set_index(['study_id', 'redcap_event_name'],inplace=True)

print entry_data
```
Tested on ncanda-storage
```bash
./update_visit_data --max-days-after-visit 120 --forms sleep_study_morning_questionnaire -v --study-id A-00068-M-4 -n
Processing the following forms:
	sleep_study_morning_questionnaire
                                           dob  exclude  visit_date  \
study_id    redcap_event_name                                         
A-00068-M-4 baseline_visit_arm_1    1995-01-18        0  2013-12-02   
            6month_followup_arm_1          NaN      NaN  2014-06-26   
            1y_visit_arm_1                 NaN      NaN  2014-12-15   
            18month_followup_arm_1         NaN      NaN  2015-09-24   
            2y_visit_arm_1                 NaN      NaN  2015-10-12   
            30month_followup_arm_1         NaN      NaN  2016-08-19   
            3y_visit_arm_1                 NaN      NaN  2016-12-14   
            baseline_night_1_arm_3         NaN      NaN         NaN   
            baseline_night_2_arm_3         NaN      NaN         NaN   
            1y_visit_night_1_arm_3         NaN      NaN         NaN   
            1y_visit_night_2_arm_3         NaN      NaN         NaN   
            2y_visit_night_1_arm_3         NaN      NaN         NaN   
            2y_visit_night_2_arm_3         NaN      NaN         NaN   
            3y_visit_night_1_arm_3         NaN      NaN         NaN   
            3y_visit_night_2_arm_3         NaN      NaN         NaN   

                                    sleep_date  sleepmor_missing  \
study_id    redcap_event_name                                      
A-00068-M-4 baseline_visit_arm_1           NaN               NaN   
            6month_followup_arm_1          NaN               NaN   
            1y_visit_arm_1                 NaN               NaN   
            18month_followup_arm_1         NaN               NaN   
            2y_visit_arm_1                 NaN               NaN   
            30month_followup_arm_1         NaN               NaN   
            3y_visit_arm_1                 NaN               NaN   
            baseline_night_1_arm_3  2014-01-11                 0   
            baseline_night_2_arm_3  2014-01-25                 0   
            1y_visit_night_1_arm_3  2015-02-21                 0   
            1y_visit_night_2_arm_3  2015-03-07               NaN   
            2y_visit_night_1_arm_3  2015-11-13               NaN   
            2y_visit_night_2_arm_3  2015-12-11               NaN   
            3y_visit_night_1_arm_3  2017-01-11               NaN   
            3y_visit_night_2_arm_3  2017-01-25               NaN   

                                        sleepmor_record_id  \
study_id    redcap_event_name                                
A-00068-M-4 baseline_visit_arm_1                       NaN   
            6month_followup_arm_1                      NaN   
            1y_visit_arm_1                             NaN   
            18month_followup_arm_1                     NaN   
            2y_visit_arm_1                             NaN   
            30month_followup_arm_1                     NaN   
            3y_visit_arm_1                             NaN   
            baseline_night_1_arm_3  A-00068-M-4-2015-12-14   
            baseline_night_2_arm_3  A-00068-M-4-2015-12-15   
            1y_visit_night_1_arm_3  A-00068-M-4-2015-12-16   
            1y_visit_night_2_arm_3                     NaN   
            2y_visit_night_1_arm_3                     NaN   
            2y_visit_night_2_arm_3                     NaN   
            3y_visit_night_1_arm_3                     NaN   
            3y_visit_night_2_arm_3                     NaN   

                                    sleep_study_morning_questionnaire_complete  
study_id    redcap_event_name                                                   
A-00068-M-4 baseline_visit_arm_1                                           NaN  
            6month_followup_arm_1                                          NaN  
            1y_visit_arm_1                                                 NaN  
            18month_followup_arm_1                                         NaN  
            2y_visit_arm_1                                                 NaN  
            30month_followup_arm_1                                         NaN  
            3y_visit_arm_1                                                 NaN  
            baseline_night_1_arm_3                                           1  
            baseline_night_2_arm_3                                           1  
            1y_visit_night_1_arm_3                                           1  
            1y_visit_night_2_arm_3                                           0  
            2y_visit_night_1_arm_3                                           0  
            2y_visit_night_2_arm_3                                           0  
            3y_visit_night_1_arm_3                                           0  
            3y_visit_night_2_arm_3                                           0  
Processing form sleepmor / sleep_study_morning_questionnaire
Record list from Import project: ['A-00068-M-4-2015-12-14', 'A-00068-M-4-2015-12-15', 'A-00068-M-4-2015-12-16', 'A-00068-M-4-2016-08-29']
Form ['sleep_study_morning_questionnaire'] has 4 records in import project.
Processing ('A-00068-M-4', 'baseline_night_1_arm_3')
Processing ('A-00068-M-4', 'baseline_night_2_arm_3')
Processing ('A-00068-M-4', '1y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '1y_visit_night_2_arm_3')
Processing ('A-00068-M-4', '2y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '2y_visit_night_2_arm_3')
Processing ('A-00068-M-4', '3y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '3y_visit_night_2_arm_3')
Uploaded 0 of 8 records to form sleep_study_morning_questionnaire
```
New logic:
```python
# Get list of existing records
if args.study_id:
    entry_data = rc_entry.export_records(records=[args.study_id], fields=entry_data_fields,
                                          event_name='unique',
                                          format='df')
else:
    entry_data = rc_entry.export_records(fields=entry_data_fields,
                                          event_name='unique',
                                          format='df')
print entry_data
```
Tested on ncanda-storage
```bash
./update_visit_data --max-days-after-visit 120 --forms sleep_study_morning_questionnaire -v --study-id A-00068-M-4 -n
Processing the following forms:
	sleep_study_morning_questionnaire
                                           dob  exclude  visit_date  \
study_id    redcap_event_name                                         
A-00068-M-4 baseline_visit_arm_1    1995-01-18        0  2013-12-02   
            6month_followup_arm_1          NaN      NaN  2014-06-26   
            1y_visit_arm_1                 NaN      NaN  2014-12-15   
            18month_followup_arm_1         NaN      NaN  2015-09-24   
            2y_visit_arm_1                 NaN      NaN  2015-10-12   
            30month_followup_arm_1         NaN      NaN  2016-08-19   
            3y_visit_arm_1                 NaN      NaN  2016-12-14   
            baseline_night_1_arm_3         NaN      NaN         NaN   
            baseline_night_2_arm_3         NaN      NaN         NaN   
            1y_visit_night_1_arm_3         NaN      NaN         NaN   
            1y_visit_night_2_arm_3         NaN      NaN         NaN   
            2y_visit_night_1_arm_3         NaN      NaN         NaN   
            2y_visit_night_2_arm_3         NaN      NaN         NaN   
            3y_visit_night_1_arm_3         NaN      NaN         NaN   
            3y_visit_night_2_arm_3         NaN      NaN         NaN   

                                    sleep_date  sleepmor_missing  \
study_id    redcap_event_name                                      
A-00068-M-4 baseline_visit_arm_1           NaN               NaN   
            6month_followup_arm_1          NaN               NaN   
            1y_visit_arm_1                 NaN               NaN   
            18month_followup_arm_1         NaN               NaN   
            2y_visit_arm_1                 NaN               NaN   
            30month_followup_arm_1         NaN               NaN   
            3y_visit_arm_1                 NaN               NaN   
            baseline_night_1_arm_3  2014-01-11                 0   
            baseline_night_2_arm_3  2014-01-25                 0   
            1y_visit_night_1_arm_3  2015-02-21                 0   
            1y_visit_night_2_arm_3  2015-03-07               NaN   
            2y_visit_night_1_arm_3  2015-11-13               NaN   
            2y_visit_night_2_arm_3  2015-12-11               NaN   
            3y_visit_night_1_arm_3  2017-01-11               NaN   
            3y_visit_night_2_arm_3  2017-01-25               NaN   

                                        sleepmor_record_id  \
study_id    redcap_event_name                                
A-00068-M-4 baseline_visit_arm_1                       NaN   
            6month_followup_arm_1                      NaN   
            1y_visit_arm_1                             NaN   
            18month_followup_arm_1                     NaN   
            2y_visit_arm_1                             NaN   
            30month_followup_arm_1                     NaN   
            3y_visit_arm_1                             NaN   
            baseline_night_1_arm_3  A-00068-M-4-2015-12-14   
            baseline_night_2_arm_3  A-00068-M-4-2015-12-15   
            1y_visit_night_1_arm_3  A-00068-M-4-2015-12-16   
            1y_visit_night_2_arm_3                     NaN   
            2y_visit_night_1_arm_3                     NaN   
            2y_visit_night_2_arm_3                     NaN   
            3y_visit_night_1_arm_3                     NaN   
            3y_visit_night_2_arm_3                     NaN   

                                    sleep_study_morning_questionnaire_complete  
study_id    redcap_event_name                                                   
A-00068-M-4 baseline_visit_arm_1                                           NaN  
            6month_followup_arm_1                                          NaN  
            1y_visit_arm_1                                                 NaN  
            18month_followup_arm_1                                         NaN  
            2y_visit_arm_1                                                 NaN  
            30month_followup_arm_1                                         NaN  
            3y_visit_arm_1                                                 NaN  
            baseline_night_1_arm_3                                           1  
            baseline_night_2_arm_3                                           1  
            1y_visit_night_1_arm_3                                           1  
            1y_visit_night_2_arm_3                                           0  
            2y_visit_night_1_arm_3                                           0  
            2y_visit_night_2_arm_3                                           0  
            3y_visit_night_1_arm_3                                           0  
            3y_visit_night_2_arm_3                                           0  
Processing form sleepmor / sleep_study_morning_questionnaire
Record list from Import project: ['A-00068-M-4-2015-12-14', 'A-00068-M-4-2015-12-15', 'A-00068-M-4-2015-12-16', 'A-00068-M-4-2016-08-29']
Form ['sleep_study_morning_questionnaire'] has 4 records in import project.
Processing ('A-00068-M-4', 'baseline_night_1_arm_3')
Processing ('A-00068-M-4', 'baseline_night_2_arm_3')
Processing ('A-00068-M-4', '1y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '1y_visit_night_2_arm_3')
Processing ('A-00068-M-4', '2y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '2y_visit_night_2_arm_3')
Processing ('A-00068-M-4', '3y_visit_night_1_arm_3')
Processing ('A-00068-M-4', '3y_visit_night_2_arm_3')
Uploaded 0 of 8 records to form sleep_study_morning_questionnaire
```

