### PR TITLE
Check object names

### DIFF
--- a/scripts/crond/back-nightly
+++ b/scripts/crond/back-nightly
@@ -44,7 +44,7 @@ catch_output_email ncanda-admin@sri.com "NCANDA REDCap: Update Form Status (upda
 
 if [ ${IMAGE_PROCESS_FLAG} == 1 ]; then
   # Check MR session names etc. in XNAT
-  catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Check Object Names Message (check_object_names)" ${SIBIS}/scripts/xnat/check_object_names -p --send-mail --zip-root /fs/ncanda-share/burn2dvd
+  catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Check Object Names Message (check_object_names)" ${SIBIS}/scripts/xnat/check_object_names -p -t /fs/ncanda-share/ncanda-data-log/back-nightly --send-mail --zip-root /fs/ncanda-share/burn2dvd
 
   # Check for new or updated sessions and
   catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Check New Sessions Message (check_new_sessions)" ${SIBIS}/scripts/xnat/check_new_sessions --send-mail-to ncanda-image-qc@sri.com -p 

--- a/scripts/xnat/check_object_names
+++ b/scripts/xnat/check_object_names
@@ -252,7 +252,6 @@ def validate_new_and_outstanding( ifc, project, objects_to_check, date_last_chec
 
 # Create interface using stored configuration
 ifc = session.connect_server('xnat', True)
-ifc._memtimeout = 0
 
 # Set up email object to contact users and admin
 from xnat_email import XnatEmail

--- a/scripts/xnat/check_object_names
+++ b/scripts/xnat/check_object_names
@@ -36,7 +36,7 @@ parser.add_argument( "-a", "--check-all", help="Check all subjects and sessions,
 parser.add_argument( "-W", "--last-week", help="Check all subjects and sessions that were modified within the last week.", action="store_true")
 parser.add_argument( "-M", "--last-month", help="Check all subjects and sessions that were modified within the last month (more precisely: the last 31 days).", action="store_true")
 parser.add_argument( "--no-update", help="Do not update the persistent data stored on the XNAT server (e.g., last run date, list of flagged sessions).", action="store_true")
-parser.add_argument("--zip-root", default=session.config.get('zip-root'), help="Root directory to create ZIP archives with T1w and T2w DICOM files for clinical reading.")
+parser.add_argument("--zip-root", default='/var/tmp/burn2dvd', help="Root directory to create ZIP archives with T1w and T2w DICOM files for clinical reading.")
 parser.add_argument("--zip-none", action="store_true", default=False, help="Do not create any ZIP archives (T1w and T2w DICOM files for clinical reading).")
 parser.add_argument("--zip-all", action="store_true", default=False, help="Create ZIP archives (T1w and T2w DICOM files for clinical reading) for all sessions, regardless of whether or not they have been processed before.")
 parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
@@ -209,8 +209,8 @@ def validate_subject( ifc, sid, slabel, sinsert ):
 #
 # Check each subject in the project
 #
-experiment_list = None
-subject_list = None
+experiment_list = []
+subject_list = []
 
 def validate_new_and_outstanding( ifc, project, objects_to_check, date_last_checked ):
     # Get all subjects and sessions from XNAT - this speeds things up a lot
@@ -252,7 +252,6 @@ def validate_new_and_outstanding( ifc, project, objects_to_check, date_last_chec
 
 # Create interface using stored configuration
 ifc = session.connect_server('xnat', True)
-ifc._memtimeout = 0
 
 # Set up email object to contact users and admin
 from xnat_email import XnatEmail
@@ -300,9 +299,6 @@ if not args.check_all:
         if args.verbose:
             print 'Unable to retrieve date of last script run and list of flagged projects from server.'
 
-        ifc = session.connect_server('xnat', True)
-        ifc._memtimeout = 0
-
 # If "last week" option is used, override last checked date
 if args.last_week:
     date_last_checked = (datetime.datetime.now() - datetime.timedelta(7)).timetuple()
@@ -336,3 +332,4 @@ if not args.no_update:
     content = ifc._exec( uri='%s?inbody=true' % config_uri, method='PUT', body=check_again_str, headers={'content-type':'text/plain'} )
 
 slog.takeTimer1("script_time","{'TotalSubjects': " + str(len(subject_list)) + ", 'TotalExperiments': " +  str(len(experiment_list)) + "}")
+

--- a/scripts/xnat/check_object_names
+++ b/scripts/xnat/check_object_names
@@ -252,6 +252,7 @@ def validate_new_and_outstanding( ifc, project, objects_to_check, date_last_chec
 
 # Create interface using stored configuration
 ifc = session.connect_server('xnat', True)
+ifc._memtimeout = 0
 
 # Set up email object to contact users and admin
 from xnat_email import XnatEmail


### PR DESCRIPTION
Tested on ncanda-share:
- github post works
- XNAT connection works
- still needs zip to be tested
```bash
 ./scripts/xnat/check_object_names -p -t /tmp/output --zip-none --no-update -v -e NCANDA_E06763 
================================
== Setting up posting to GitHub 
Setting up GitHub...
Parsing config: ~/.server_config/github.cfg
Connected to GitHub
... ready!
Found label: [Label(name="check_object_names")]
== Posting to GitHub is ready 
================================
Posting check_object_names test error
Checking for issue: check_object_names test, error
Open issue already exists... See: https://api.github.com/repos/sibis-platform/ncanda-operations/issues/3216
Script was last run 2017-05-16 22:00:03.04
Unable to retrieve date of last script run and list of flagged projects from server.
INFO: checking experiment E-01074-F-7-20170513 (NCANDA_E06784)
INFO: checking experiment E-99999-P-9-20170509 (NCANDA_E06785)
INFO: checking experiment E-00000-P-0-20170509 (NCANDA_E06786)
INFO: checking experiment E-99999-P-9-20170511 (NCANDA_E06787)
INFO: checking experiment E-99999-P-9-20170513 (NCANDA_E06788)
INFO: checking experiment E-99999-P-9-20170515 (NCANDA_E06792)
INFO: checking experiment E-00000-P-0-20170515 (NCANDA_E06794)
INFO: checking experiment C-70174-F-2-20170515 (NCANDA_E06789)
INFO: checking experiment C-99999-P-9-20170515 (NCANDA_E06791)
INFO: checking experiment C-00000-P-0-20170515 (NCANDA_E06795)
INFO: checking experiment D-00076-F-0-20170515 (NCANDA_E06800)
INFO: checking experiment D-99999-P-9-20170515 (NCANDA_E06801)
INFO: checking experiment A-00000-P-0-20170516 (NCANDA_E06779)
INFO: checking experiment A-99999-P-9-20170516 (NCANDA_E06781)
INFO: checking experiment A-00044-F-8-20170516 (NCANDA_E06783)
INFO: checking experiment A-99999-P-9-20170517 (NCANDA_E06797)
INFO: checking experiment A-00025-M-3-20170517 (NCANDA_E06799)

/tmp/output

start-time,end-time,difference-min:sec:msec,label,extra-info
2017-05-17 14:26:29,2017-05-17 14:26:29,0:00:001,connect_xnat,
2017-05-17 14:26:45,2017-05-17 14:26:45,0:00:001,connect_xnat,
2017-05-17 14:29:50,2017-05-17 14:29:50,0:00:001,connect_xnat,
2017-05-17 14:29:50,2017-05-17 14:29:50,0:00:001,connect_xnat,
2017-05-17 14:34:11,2017-05-17 14:34:11,0:00:001,connect_xnat,
2017-05-17 14:34:11,2017-05-17 14:34:11,0:00:000,connect_xnat,
2017-05-17 14:34:11,2017-05-17 14:34:28,0:17:025,script_time,"{'TotalSubjects': 0, 'TotalExperiments': 0}"

```