### PR TITLE
added options to front-hourly for phantom_qa

### DIFF
--- a/scripts/crond/front-hourly
+++ b/scripts/crond/front-hourly
@@ -21,22 +21,23 @@ hour=$(date +%H)
 
 # Run QA on fBIRN and ADNI phantom scans
 if [ ${XNAT_FLAG} == 1 ]; then
-   catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Phantom QA Messages (phantom_qa)" ${SIBIS}/scripts/xnat/phantom_qa
-else 
+   catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Phantom QA Messages (phantom_qa)" -p \
+       -t /fs/ncanda-share/ncanda-data-log/front-hourly ${SIBIS}/scripts/xnat/phantom_qa
+else
    if [ ${hour} -eq 0 ]; then
-      echo "front-nightly: Warning: XNAT updates are disabled !"    
+      echo "front-nightly: Warning: XNAT updates are disabled !"
    fi
-fi 
+fi
 
 
 # Import data from the sites' data capture laptops into REDCap and reconcile imported with longitudinal data
 if [ ${IMPORT_FLAG} == 1 ]; then
   catch_output_email ncanda-admin@sri.com "NCANDA: Laptop Data Import Stage 1 (harvester)" ${SIBIS}/scripts/import/laptops/harvester -p /fs/storage/laptops/ncanda /fs/storage/laptops/imported
-else 
+else
    if [ ${hour} -eq 0 ]; then
-      echo "front-nightly: Warning: Import from laptops  disabled !"    
+      echo "front-nightly: Warning: Import from laptops  disabled !"
    fi
-fi 
+fi
 
 #
 # Previouly front-nighlty

--- a/scripts/crond/front-hourly
+++ b/scripts/crond/front-hourly
@@ -20,9 +20,12 @@ IMPORT_FLAG=1
 hour=$(date +%H)
 
 # Run QA on fBIRN and ADNI phantom scans
+qa_args="-p"
+if [ ${hour} -eq 0 ]; then
+    qa_args+=" -t /fs/ncanda-share/ncanda-data-log/front-hourly"
+fi  
 if [ ${XNAT_FLAG} == 1 ]; then
-   catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Phantom QA Messages (phantom_qa)" -p \
-       -t /fs/ncanda-share/ncanda-data-log/front-hourly ${SIBIS}/scripts/xnat/phantom_qa
+   catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Phantom QA Messages (phantom_qa)" ${SIBIS}/scripts/xnat/phantom_qa  ${qa_args}
 else
    if [ ${hour} -eq 0 ]; then
       echo "front-nightly: Warning: XNAT updates are disabled !"
@@ -32,7 +35,7 @@ fi
 
 # Import data from the sites' data capture laptops into REDCap and reconcile imported with longitudinal data
 if [ ${IMPORT_FLAG} == 1 ]; then
-  catch_output_email ncanda-admin@sri.com "NCANDA: Laptop Data Import Stage 1 (harvester)" ${SIBIS}/scripts/import/laptops/harvester -p /fs/storage/laptops/ncanda /fs/storage/laptops/imported
+  catch_output_email ncanda-admin@sri.com "NCANDA: Laptop Data Import Stage 1 (harvester)" ${SIBIS}/scripts/import/laptops/harvester ${qa_args} /fs/storage/laptops/ncanda /fs/storage/laptops/imported
 else
    if [ ${hour} -eq 0 ]; then
       echo "front-nightly: Warning: Import from laptops  disabled !"
@@ -49,6 +52,4 @@ if [ ${hour} -eq 0 ]; then
     update_args+="--update-all"
 fi
 catch_output_email ncanda-admin@sri.com "NCANDA REDCap: Update Scores (update_summary_scores)" \
-    ${SIBIS}/scripts/redcap/update_summary_scores -p \
-    -t /fs/ncanda-share/ncanda-data-log/front-hourly \
-    ${update_args}
+    ${SIBIS}/scripts/redcap/update_summary_scores ${update_args} ${qa_args}


### PR DESCRIPTION
Trailing spaces are removed by Atom IDE, it is quite handy, it also warns you of compilation problems beforehand. 
Line on back-nightly that calls fmri_qa_subjects is commented:
  ##catch_output_email ncanda-admin@sri.com "NCANDA XNAT: Subject fMRI QA Messages" ${SIBIS}/scripts/xnat/fmri_qa_subjects