### PR TITLE
Pick up Yes/No in datadict in either order

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -368,7 +368,7 @@ if not redcap_project :
 summary_field_names = [field['field_name'] for field in redcap_project.metadata]
 
 # Get list of all 0/1 encoded Yes/No fields (either radio or dropdown) - these need to be recoded when copied
-summary_fields_yn = [field['field_name'] for field in redcap_project.metadata if field['field_type'] in ['radio', 'dropdown'] and re.match('[^0-9]*1, Yes[^0-9]*0, No.*', field['select_choices_or_calculations'])]
+summary_fields_yn = [field['field_name'] for field in redcap_project.metadata if field['field_type'] in ['radio', 'dropdown'] and re.match('([^0-9]*0, No[^0-9]*1, Yes.*|[^0-9]*1, Yes[^0-9]*0, No.*)', field['select_choices_or_calculations'])]
 
 # What forms are at what event?
 form_event_mapping = redcap_project.export_fem(format='df')

--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -368,6 +368,7 @@ if not redcap_project :
 summary_field_names = [field['field_name'] for field in redcap_project.metadata]
 
 # Get list of all 0/1 encoded Yes/No fields (either radio or dropdown) - these need to be recoded when copied
+# NOTE: Regex altered to work with either order of Yes/No options
 summary_fields_yn = [field['field_name'] for field in redcap_project.metadata if field['field_type'] in ['radio', 'dropdown'] and re.match('([^0-9]*0, No[^0-9]*1, Yes.*|[^0-9]*1, Yes[^0-9]*0, No.*)', field['select_choices_or_calculations'])]
 
 # What forms are at what event?


### PR DESCRIPTION
This resolves an issue where, after an update to the data dictionary
that reversed the order of Yes/No options, the conversion of Y/N to 1/0
wouldn't be triggered.

Testing done in production.