### PR TITLE
Add "yesno" as a valid fieldtype for YN->10 alteration

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -381,7 +381,11 @@ summary_field_names = [field['field_name'] for field in redcap_project.metadata]
 
 # Get list of all 0/1 encoded Yes/No fields (either radio or dropdown) - these need to be recoded when copied
 # NOTE: Regex altered to work with either order of Yes/No options
-summary_fields_yn = [field['field_name'] for field in redcap_project.metadata if field['field_type'] in ['radio', 'dropdown'] and re.match('([^0-9]*0, No[^0-9]*1, Yes.*|[^0-9]*1, Yes[^0-9]*0, No.*)', field['select_choices_or_calculations'])]
+summary_fields_yn = [field['field_name'] for field in redcap_project.metadata
+                     if ((field['field_type'] == "yesno") or
+                         (field['field_type'] in ['radio', 'dropdown'] and
+                          re.match('([^0-9]*0, No[^0-9]*1, Yes.*|[^0-9]*1, Yes[^0-9]*0, No.*)',
+                                   field['select_choices_or_calculations'])))]
 
 # What forms are at what event?
 form_event_mapping = redcap_project.export_fem(format='df')


### PR DESCRIPTION
Addresses the recent spate of errors (e.g. sibis-platform/ncanda-operations#6973), all of which are happening because `mrireport_mri_set5_mrilu9av2` and `mrireport_mri_set5_mrilu11av2` have Field Type "yesno". This is a valid use case for converting from LimeSurvey-type "Y, Yes | N, No" coding to 1/0.