### PR TITLE
Work around misdating and stop misnaming

### DIFF
--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -154,7 +154,7 @@ def run_converter(site, subject_label, command,verbose):
 
         for fi in added_files.strip().split('\n'):
             if re.match('.*\.csv$', fi):
-                if os.path.basename(fi).split('-')[0] == 'NOID' : 
+                if os.path.basename(fi).split('-')[0] in ['NOID', 'nan']: 
                     slog.info(subject_label + "-" +  hashlib.sha1('harvester {}'.format(fi)).hexdigest()[0:6], 'converter_cmd created file that does not contain subject ID and thus cannot be uploaded to redcap',
                               file=str(fi),
                               converter_cmd=" ".join(command), 

--- a/scripts/import/laptops/lime2csv
+++ b/scripts/import/laptops/lime2csv
@@ -94,7 +94,9 @@ def compute_survey_date( row, this_survey ):
         try:
             date = str( row['%s_%s' % (this_survey,field)] )
             if len( date ) >= 10:
-                return date[0:10]
+                return_date = fix_dates(date[0:10], this_survey)
+                if int(return_date[0:4]) >= 2010:
+                    return return_date[0:10]
         except:
             pass
 


### PR DESCRIPTION
Provides a workaround for sibis-platform/ncanda-operations#6970 (by looking at other dates if current date precedes 2010) and sibis-platform/ncanda-operations#7005 (by raising an error if `harvester` attempts to convert a file with `nan` subject ID). 

Both issues require UCSD action to fix, but this PR should be a sufficient workaround for the former, and a small help for the latter. Right now, upload of malformed-raw-file-derived processed CSVs only throws an error if the mis-aligned fields fail validation (see: sibis-platform/ncanda-operations#6896, sibis-platform/ncanda-operations#6900).