### PR TITLE
Check multiple scans

### DIFF
--- a/scripts/reporting/check_univariate_outliers.py
+++ b/scripts/reporting/check_univariate_outliers.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+"""
+Get values outside of `n` standard deviations of the given variable(s).
+
+Sample use:
+
+    ./check_univariate_outliers.py \
+      --last-event 3 \
+      --subject-list ./subjects-include.txt \
+      --columns measure_brainsegvol measure_rhcortexvol measure_lhcortexvol \
+                measure_rhcorticalwhitemattervol measure_lhcorticalwhitemattervol \
+                measure_subcortgrayvol measure_totalgrayvol \
+                measure_supratentorialvol measure_etiv \
+      -- $SOURCE_FILE > $RESULT_FILE 
+
+    ./check_univariate_outliers.py \
+      --last-event 3 \
+      --subject-list ./subjects-include.txt \
+      --column-regex "_grayvol$" \
+      -- $SOURCE_FILE1 $SOURCE_FILE2 > $RESULT_FILE 
+"""
+# TODO: Actually use longitudinal outlier check
+# TODO: Test normalization by column from a different file
+
+import pandas as pd
+
+
+def number_to_event_name(number):
+    """
+    Convert an integer to an NCANDA event name (Arm 1 + full-year visits only)
+    """
+    if number == 0:
+        return "baseline"
+    elif number >= 1:
+        return "followup_%dy" % number
+    else:
+        raise KeyError("Number %d is not eligible for conversion" % number)
+
+
+def event_name_to_number(event_name):
+    """
+    Convert an NCANDA event name to an integer (Arm 1 + full-year visits only)
+    """
+    import re
+    if event_name == "baseline":
+        return 0
+    else:
+        match_obj = re.match(r'^followup_(\d+)y$', event_name)
+        if match_obj:
+            return int(match_obj.groups()[0])
+
+
+def prepare_subject_list(subject_list):
+    pass
+
+
+def prepare_file(filename, primary_keys, columns=None, column_regex=None,
+                 all_arms=False, subject_list=None, last_event=None,
+                 normalize_file=None, normalize_column=None):
+    # Call:
+    # selected_args = ['columns', 'column_regex', 'all_arms', 'subject_list',
+    #                  'last_event', 'normalize_file', 'normalize_column']
+    # prepare_file(filename, primary_keys=PRIMARY_KEYS,
+    #              **dict(zip(selected_args,
+    #                         attrgetter(*selected_args)(args))))
+    # prepare_file(filename, primary_keys=PRIMARY_KEYS,
+    #              *attrgetter(*selected_args)(args))
+    pass
+
+
+def get_univariate_outliers_in_file(filename, sd_count=3, reference="baseline",
+                                    verbose=False):
+
+    if args.columns:
+        df = pd.read_csv(filename,
+                         index_col=PRIMARY_KEYS,
+                         usecols=PRIMARY_KEYS + args.columns)
+    else:
+        df = pd.read_csv(filename,
+                         index_col=PRIMARY_KEYS)
+
+    if args.column_regex:
+        df = df.filter(regex=args.column_regex)
+
+    if not args.all_arms:
+        df = df.xs('standard', level='arm')
+
+    if args.subject_list:
+        with open(args.subject_list, 'r') as subject_file:
+            subjects = [x.strip() for x in subject_file.readlines()]
+        df = df[df.index.get_level_values(level='subject').isin(subjects)]
+
+    if args.last_event:
+        all_events = [number_to_event_name(x) for x
+                      in xrange(0, args.last_event + 1)]
+        df = df[df.index.get_level_values(level='visit').isin(all_events)]
+
+    if args.normalize_file:
+        if not args.normalize_column:
+            raise NotImplementedError(("Cannot provide --normalize-file"
+                                       " without --normalize-column!"))
+        else:
+            df = normalize_by_column_from_file(df,
+                                               args.normalize_file,
+                                               args.normalize_column,
+                                               keep_normalizer=False)
+    elif args.normalize_column:
+        df = normalize_by_column_in_df(df, args.normalize_column)
+
+    baseline_only = (reference == "baseline")
+    outliers = df.apply(pick_univariate_outliers, sd_count=sd_count,
+                        verbose=verbose, baseline_only=baseline_only)
+    outlier_values = df.mask(~outliers).stack().to_frame('outlier_value')
+    outlier_values.index.set_names('variable', -1, inplace=True)
+
+    outlier_values['file'] = filename
+    outlier_values.set_index(['file'], append=True, inplace=True)
+    # outlier_values.reorder_levels
+    return outlier_values
+
+
+def normalize_by_column_in_df(df, colname):
+    # Process:
+    # 1. Create a df copy
+    # 2. Copy df[colname] to df_divisor[other_col] for all other colnames
+    # 3. df_divisor[other_col] = 1
+    # 4. Return df.div(df_divisor)
+    df2 = pd.DataFrame().reindex_like(df)
+    df2 = df2.assign(**{col: df[colname] for col in df2.columns})
+    # Alternative for older pandas: iterate through df2.columns and assign
+    # df[colname]
+    df2[colname] = 1.0  # To preserve the value of the normalizing column
+    return df.divide(df2)
+
+
+def normalize_by_column_from_file(df, filename, colname,
+                                  keep_normalizer=False):
+    """
+    Wrapper over `normalize_by_column_in_df` that loads another CSV file with
+    normalizing value in `colname`  into a pandas.DataFrame, which it joins
+    onto `df`.
+
+    - Deletes the normalizing column from `df` afterwards unless
+        `keep_normalizer` is `True`.
+    - Assumes the existence of the same primary keys in `filename`.
+    """
+    # TODO: Take primary keys from df instead of the PRIMARY_KEYS const, e.g.:
+    #   usecols = df.index.names + [colname]
+    df_norm = pd.read_csv(filename, index_cols=PRIMARY_KEYS,
+                          usecols=PRIMARY_KEYS + [colname])
+    df_join = normalize_by_column_in_df(df.join(df_norm), colname)
+    if not keep_normalizer:
+        df_join.drop(columns=[colname], inplace=True)
+    return df_join
+
+
+def pick_univariate_outliers(df_col, sd_count=3, baseline_only=False,
+                             verbose=False):
+    colname = df_col.name
+    year_min, year_max = ((df_col.groupby(['visit']).mean() -
+                           sd_count * df_col.groupby(['visit']).std())
+                          .to_frame('col_min'),
+                          (df_col.groupby(['visit']).mean() +
+                           sd_count * df_col.groupby(['visit']).std())
+                          .to_frame('col_max'))
+    if baseline_only:
+        # TODO: Also implement for reference = "all"
+        year_min = year_min.loc['baseline'].squeeze()
+        year_max = year_max.loc['baseline'].squeeze()
+
+        return (df_col < year_min) | (df_col > year_max)
+    else:
+        df_col = df_col.to_frame().join(year_min).join(year_max)
+        return ((df_col[colname] < df_col['col_min']) |
+                (df_col[colname] > df_col['col_max']))
+
+
+def pick_longitudinal_outliers(df, fn):
+    # Approach:
+    #   1. From indexed df, get df.columns
+    #   2. Group df by ['subject', 'arm']
+    #   3. Accumulate a dict of data frames with residuals / other linreg stats
+    #      for each column
+    #   4. Concatenate horizontally
+    cols = df.columns.tolist()
+    df_grouped = df.reset_index().groupby(['subject', 'arm'])
+    return pd.concat([df_grouped.apply(fn, colname=x) for x in cols],
+                     axis=1)
+
+
+def get_aic(df_grp, colname, longit_col="visit"):
+    # Or any other per-subject linreg stat
+    import statsmodels.formula.api as smf
+    result = smf.ols(colname + ' ~ ' + longit_col, df_grp).fit()
+    return pd.Series({colname: result.aic})
+    # Should be generalized with pd.Series{colname: attrgetter(stat)(result)}
+
+
+def get_residuals(df_grp, colname, longit_col="visit"):
+    # Or any other per-timepoint linreg stat
+    import statsmodels.formula.api as smf
+    result = smf.ols(colname + ' ~ ' + longit_col, df_grp).fit()
+    # Assignment is important because it sets up the index
+    df_grp[colname] = result.resid
+    # Should be generalized with df_grp[colname] = attrgetter(stat)(result)
+    return df_grp[colname]
+
+PRIMARY_KEYS = ["visit", "subject", "arm"]
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog='check_univariate_outliers',
+        description=('For all variables in passed files, print out the ones'
+                     'that are beyond 3 SDs of their mean.'))
+    parser.add_argument("-v", "--verbose",
+                        help="Verbose operation",
+                        action="store_true")
+    parser.add_argument("--sd-count",
+                        help="Flag beyond how many SDs?",
+                        default=3, action="store")
+    parser.add_argument("--all-arms",
+                        help="Prevent removal of non-standard arms",
+                        default=False, action="store")
+    parser.add_argument('--reference',
+                        default='baseline',
+                        choices=['baseline', 'year', 'all'],
+                        help=('Which means/SDs to compare to? "year" keeps the'
+                              'comparison within each event; "baseline" relies'
+                              'only on the baseline reference; and "all" mixes'
+                              'all together.'))
+    parser.add_argument('-e', '--last-event', type=int,
+                        help="Last event to include as int (baseline=0)")
+    parser.add_argument('-s', '--subject-list',
+                        help="File with newline-separated IDs to include")
+    parser.add_argument('-c', '--columns', nargs='*', default=None,
+                        help="Column(s) to check")
+    parser.add_argument('--column-regex', default=None,
+                        help="Regex for columns to preserve")
+    # TODO: Implement this bit of logic
+    parser.add_argument('--normalize-file', default=None,
+                        help=("File that contains the normalizing column"
+                              "specified in --normalize-column, as well as"
+                              "primary keys equivalent to the file under"
+                              "analysis"))
+    parser.add_argument('--normalize-column', default=None,
+                        help=("Column to normalize by. If --normalize-file is"
+                              "not provided, this column is assumed to be in"
+                              "the file(s) to be analyzed."))
+    parser.add_argument('-o', '--outfile', default=sys.stdout)
+    parser.add_argument('files', nargs='+',
+                        help="Paths to CSV files to analyze")
+    args = parser.parse_args()
+
+    # make_header = True
+    file_dfs = []
+    for f in args.files:
+        if args.verbose:
+            print "Now processing %s..." % f
+        # TODO: Join with get_longitudinal_outliers, when that's written
+        file_dfs.append(
+            get_univariate_outliers_in_file(f, sd_count=args.sd_count,
+                                            reference=args.reference,
+                                            verbose=args.verbose))
+    (pd.concat(file_dfs, axis=0)
+     .reorder_levels(order=["subject", "visit", "file", "variable"])
+     .sort_index(level=["subject", "visit"])
+     .to_csv(args.outfile))

--- a/scripts/reporting/duplicate_scans_check
+++ b/scripts/reporting/duplicate_scans_check
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+"""
+
+Based on an independent regeneration of scans-to-Redcap-event assignments,
+determine cases where more than one usable scan of a particular scan type
+belongs to one subject/event.
+
+Example uses:
+
+    ./check_multiple_scans --outfile /tmp/duplicate_scans.csv \
+        --redcapcsv /tmp/redcap_inventory.csv --xnatcsv /tmp/xnat_inventory.csv
+
+"""
+
+import ipdb
+import sys
+import argparse
+
+from itertools import chain
+import pandas as pd
+import numpy as np
+
+def add_end_window(rc, max_days=120, include_recovery_after_baseline=True, 
+                   verbose=False):
+    """
+    Implements the rules from 
+    <https://neuro.sri.com/labwiki/index.php/NCANDA_REDCap:_Imported_Record_to_Visit_Assignment>:
+
+        1. For each visit, data within a 120-day window after the entered
+           "Visit Date" are assigned to that visit.
+        2. If a subsequent visit with MRI collection happened less than 120
+           days after the visit (e.g., a "Recovery Final" visit 30 days after
+           "Recovery Baseline"), then only data before the subsequent visit
+           are permissible.
+        3. The "Recovery Baseline" visit does not shorten the search window for
+           the preceding visit of the standard protocol, because the standard
+           protocol MRI also serve as the data for the Recovery branch (except
+           for mid-year Recovery visits at Duke, where an additional Recovery
+           baseline scan will be collected according to Mike DeBellis).
+        4. The "Recovery Baseline" MRI must be acquired on the same date as
+           entered, because the MRI collection day is the first day of the
+           Recovery protocol.
+
+    """
+    standard_window = pd.Timedelta(days=max_days)
+
+    # We'll create a new column, 'window_end' = last date  on which a scan can
+    # be associated
+
+    # 1. Get next visit value from as provisional window end
+    # FIXME: Should Recovery Final truncate the previous full-year scan eligibility?
+    #   By plain reading of the rules, yes, but I don't think
+    #   import_mr_sessions implements it that way
+    recovery_baseline_idx = rc.redcap_event_name == "recovery_baseline_arm_2"
+    all_recovery_idx = rc.redcap_event_name.str.contains(r'arm_2$')
+    if include_recovery_after_baseline:
+        exclude_idx = recovery_baseline_idx
+    else:
+        exclude_idx = all_recovery_idx
+
+    rc.loc[~exclude_idx, 'window_end'] = \
+        (rc.loc[~exclude_idx, :]
+         .groupby(['study_id'])['visit_date'].shift(-1))
+
+    # need to fill in windows for recovery baseline, which is always
+    # the next recovery value
+    rc.loc[recovery_baseline_idx, 'window_end'] = \
+        (rc.loc[all_recovery_idx, :]
+         .groupby(['study_id'])['visit_date'].shift(-1)
+         .loc[recovery_baseline_idx])
+    if not include_recovery_after_baseline:
+        pass
+        # need to fill in recovery baseline AND find if recovery final is
+        # truncated
+        # FIXME: I think for now, the assumption is that recovery final is
+        # never truncated
+
+    ## 2. ...but kill any values that this set improperly -- i.e. same-day or in the past:
+    # TODO: Should this raise?
+    questionable_idx = rc['window_end'].notnull() & (rc['window_end'] <= rc['visit_date'])
+    if verbose:
+        print "The following records result in a strangely calculated window_end"
+        print rc.loc[questionable_idx]
+        # import ipdb; ipdb.set_trace()
+    rc.loc[questionable_idx, 'window_end'] = pd.NaT
+
+    # 3. If window end is outside the standard window or null, cap at standard window
+    standard_visit_idx = (rc.window_end - rc.visit_date > standard_window) | rc.window_end.isnull()
+    rc.loc[standard_visit_idx, "window_end"] = rc.visit_date + standard_window
+
+    return rc
+
+
+
+def main(args):
+    xnat = pd.read_csv(args.xnatcsv)
+
+    # Only keep interesting scans
+    ncanda_scan_types = [ 't1spgr', 'mprage', 't2fse', 'dti6b500pepolar', 'dti30b400', 'dti60b1000', 'rsfmri' ]
+    eligible_idx = pd.Series(index=xnat.index)
+    eligible_idx[:] = False
+    for eligible_type in ncanda_scan_types:
+        eligible_idx = eligible_idx | xnat.scan_type.str.contains(eligible_type, na=False)
+    xnat = xnat[eligible_idx]
+
+    # Only keep usable scans
+    permissible_qualities = ["usable"]
+    if args.usable_extra:
+        permissible_qualities.append("usable-extra")
+    xnat = xnat[xnat["quality"].isin(permissible_qualities)]
+
+    xnat.experiment_date = pd.to_datetime(xnat.experiment_date)
+    #xnat.sort_values(["experiment_date", "site_id"], inplace=True)  # introduced in later pandas
+    xnat.sort(["experiment_date", "site_id"], inplace=True)
+
+    rc = pd.read_csv(args.redcapcsv)
+    # TODO: Should get events with mr_session_report from FEM
+    rc = rc[~rc["redcap_event_name"].str.contains("month|weekly", na=False)]
+    rc = rc[~(rc["visit_ignore___yes"] == 1)]
+    rc = rc[~(rc["mri_missing"] == 1)]
+    rc = rc.dropna(subset=["visit_date"])
+    rc.visit_date = pd.to_datetime(rc.visit_date)
+    #rc.sort_values(["visit_date", "study_id"], inplace=True)
+    rc.sort(["visit_date", "study_id"], inplace=True)
+    rc = add_end_window(rc, verbose=args.verbose)
+
+    if args.subjectlist:
+        with args.subjectlist as f:
+            subjects = [s.strip() for s in f.readlines()]
+        xnat = xnat[xnat.subject_id.isin(subjects)]
+
+    #pd.merge_asof(xnat, rc, left_on="experiment_date", right_on="visit_date",
+    #        left_by="study_id", right_by="site_id")
+    # What follows is essentially equivalent to merge_asof, except that the
+    # one-to-many merge that would have happened is instead represented by
+    # nested array in a single cell.
+
+    xnat['redcap_event_count'] = 0
+    xnat["redcap_all_events_count"] = 0
+    for idx, xnat_row in xnat.iterrows():
+        # This works because for a single row, .loc retrieves the pure value
+        matching_rc = ((rc['visit_date'] <= xnat_row.loc['experiment_date']) &
+                       (rc['window_end'] >  xnat_row.loc['experiment_date']) &
+                       (rc['study_id'] == xnat_row.loc['site_id']))
+        rc_row = rc[matching_rc]
+        if not rc_row.empty:
+            events = rc_row['redcap_event_name'].values
+            orig_count = len(events)
+            if not args.all_arms:
+                events = [e for e in events if e.endswith("arm_1")]
+            xnat.at[idx, "redcap_all_events_count"] = orig_count
+            xnat.at[idx, "redcap_event_count"] = len(events)
+            if len(events) > 0:
+                xnat.at[idx, "redcap_events"] = events
+                xnat.at[idx, "redcap_event_string"] = ",".join(sorted(events))
+
+    ## Scans with a single target (simpler to deal with for now)
+    # TODO: Figure out the unnesting so that it works for an
+    # arbitrary number of associated events
+    grouping_vars = ['redcap_event_string', 'site_id', 'scan_type']
+    xnat1 = xnat[xnat.redcap_event_count == 1]
+    xnat1_counts = xnat1.groupby(grouping_vars).size().to_frame('scans_per_event')
+    xnat1.set_index(grouping_vars, inplace=True)
+    xnat1 = xnat1.join(xnat1_counts)
+    xnat1_duplicates = xnat1[xnat1['scans_per_event'] > 1]
+    xnat1_duplicates.to_csv(args.outfile)
+    # This is it! These are the duplicates! We don't need no
+    # other!
+
+    # import ipdb; ipdb.set_trace()
+    return
+
+
+    ## Problems
+    # TODO: Should these be investigated?
+    idx_not_matched = xnat['redcap_event_count'] == 0
+    not_matched = xnat[idx_not_matched]
+    eids_unmatched = not_matched.experiment_id.unique()
+    all_imported_eids = rc.mri_xnat_eids.str.split(" ").dropna().values
+    all_imported_eids = [item for sublist in all_imported_eids for item in sublist]
+    # xnat = xnat[~idx_not_matched]
+    # FIXME: Need to debug why these are failing -- maybe they're special cases?
+    match_failures = [eid for eid in eids_unmatched if eid in all_imported_eids]
+    truly_unmatched = [eid for eid in eids_unmatched if eid not in all_imported_eids]
+
+    # This unnests the associated scans while preserving
+    # FIXME: This definitely needs work -- not actually correct
+    xnat_long = xnat.set_index(['site_id', 'scan_type']).join(xnat.set_index(['site_id', 'scan_type']).redcap_events.apply(pd.Series).stack().reset_index(level=2))
+    # xnat['count'] = xnat.groupby(["site_id", "scan_type", "redcap_event"])["scan_type"].transform('count')
+    #xnat.groupby(["site_id", "scan_type", "redcap_event"]).size()
+    # FIXME: This currently outputs the number of scans that belong to more than one event, which isn't what were after
+    xnat[xnat['redcap_event_count'] > 1].to_csv(args.outfile)
+    return 0
+
+if __name__ == '__main__':
+    formatter = argparse.RawDescriptionHelpFormatter
+    default = 'default: %(default)s'
+
+    parser = argparse.ArgumentParser(prog="duplicate_scans_check",
+                                     description=__doc__,
+                                     formatter_class=formatter)
+    parser.add_argument('-e', '--events', dest="events", action='store',
+            nargs="+",
+            default=["baseline_visit_arm_1", "1y_visit_arm_1", "2y_visit_arm_1", "3y_visit_arm_1"])
+    parser.add_argument('--xnat', dest="xnatcsv", action='store',
+                        help="The csv file containing all usable eids generated by scripts/reporting/xnat_sessions_report.py --usable --ignore-window",
+                        type=argparse.FileType('r'))
+    parser.add_argument('--red', dest="redcapcsv", action="store",
+                        help="The CSV containing the data from redcap - generated by scripts/reporting/create_redcap_visit_list.py --all-events",
+                        type=argparse.FileType('r'))
+
+    #parser.add_argument('--special_cases', action="store",
+    #                    help="location of ncanda-operations/special_cases.yml")
+
+    parser.add_argument('-s', '--subjectlist', dest="subjectlist",
+                        help="Text file containing the sID (NCANDA_S00033) of interest", 
+                        action='store',
+                        type=argparse.FileType('r'))
+    parser.add_argument('-o', '--outfile',
+                        help="Text file to write the results into", 
+                        default=sys.stdout,
+                        action='store',
+                        type=argparse.FileType('w'))
+    parser.add_argument("-a", "--all-arms",
+                        help="Consider scan duplication on all arms",
+                        default=False,
+                        action="store_true")
+    parser.add_argument("--usable-extra",
+                        help="Consider usable-extra scans in addition to usable scans",
+                        default=False,
+                        action="store_true")
+    parser.add_argument("-v", "--verbose",
+                        help="Verbose operation",
+                        action="store_true")
+    parsed_args = parser.parse_args()
+    sys.exit(main(args=parsed_args))

--- a/scripts/reporting/test/test_outlier_detection.py
+++ b/scripts/reporting/test/test_outlier_detection.py
@@ -1,0 +1,99 @@
+import pytest
+import pandas as pd
+import numpy as np
+from check_univariate_outliers import pick_univariate_outliers
+
+s = np.random.seed(54920)
+
+
+def make_df_with_outliers(mean, std, size, colname, values_to_insert=None, **kwargs):
+    data = np.random.normal(loc=mean, scale=std, size=size)
+    if values_to_insert:
+        data = np.append(np.array(values_to_insert), data)
+    df_args = kwargs
+    df_args[colname] = data
+    return pd.DataFrame(df_args)
+
+# make_df_with_outliers(2000, 100, 10, colname="brain_volume", 
+#                       values_to_insert=[1600, 2400], arm="standard", visit="baseline")
+
+
+@pytest.fixture
+def df_within_limits(mean=1000, sd=100, size=1000):
+    df = make_df_with_outliers(mean, sd, size, colname="brain_volume",
+                               arm="standard", visit="baseline")
+    df.index.names = ['subject']
+    df.set_index(['visit', 'arm'], append=True, inplace=True)
+    return df
+
+
+@pytest.fixture
+def df_baseline(mean=2000, sd=100, size=1000):
+    df = make_df_with_outliers(mean, sd, size, colname="brain_volume",
+                               values_to_insert=[mean - 4*sd, mean + 4*sd],
+                               arm="standard", visit="baseline")
+    df.index.names = ['subject']
+    df.set_index(['visit', 'arm'], append=True, inplace=True)
+    return df
+
+
+@pytest.fixture
+def df_year1(mean=2000, sd=50, size=1000):
+    df = make_df_with_outliers(mean, sd, size, colname="brain_volume",
+                               values_to_insert=[mean - 4*sd, mean + 4*sd],
+                               arm="standard", visit="followup_1y")
+    df.index.names = ['subject']
+    df.set_index(['visit', 'arm'], append=True, inplace=True)
+    return df
+
+
+@pytest.fixture
+def df_nice():
+    data = [0] * 5 + [10] * 90 + [1000] * 4 + [10000]  # mean: 149, sd = 1008.9
+    df = make_df_with_outliers(0, 1, 0, colname="brain_volume",
+                               values_to_insert=data,
+                               arm="standard", visit="baseline")
+    df.index.names = ['subject']
+    df.set_index(['visit', 'arm'], append=True, inplace=True)
+    return df
+
+
+def test_catches_outlier(df_nice):
+    result = df_nice.mask(~df_nice.apply(pick_univariate_outliers,
+                                         sd_count=3)).stack()
+    assert result.shape[0] == 1
+    assert result.values == [10000]
+
+# 0. Sanity checks:
+#   a. Should return a series
+#   b. Should return no outliers if everything is within limits
+def test_returns_series(df_within_limits):
+    result = df_within_limits.mask(
+        ~df_within_limits.apply(pick_univariate_outliers,
+                                sd_count=3.5)).stack()
+    assert type(result) == pd.core.series.Series
+    assert result.shape[0] == 0
+
+# Others:
+# - It should throw an error if the data frame is not indexed / indexes are not
+#   named correctly
+# - Should error out if there is now baseline visit
+
+# Tests:
+# 1. Testing df_baseline should find the two outliers
+def test_baseline_finds(df_baseline):
+    result = df_baseline.mask(~df_baseline.apply(pick_univariate_outliers)).stack()
+    assert result.shape[0] >= 2
+    assert result.shape[0] <= 2 + int(np.round(0.002 * df_baseline.shape[0]))
+
+# 2. Testing df_baseline + df_year1 should find two outliers if baseline-only
+#   is enabled, four if not
+def test_year1_ok_if_baseline_only(df_baseline, df_year1):
+    df = pd.concat([df_baseline, df_year1], axis=0)
+    result = df.mask(~df.apply(pick_univariate_outliers, baseline_only=True)).stack()
+    assert (result.reset_index(['visit'])['visit'] != "followup_1y").all()
+
+def test_year1_outliers_if_per_year(df_baseline, df_year1):
+    df = pd.concat([df_baseline, df_year1], axis=0)
+    result = df.mask(~df.apply(pick_univariate_outliers, baseline_only=False)).stack()
+    assert (result.reset_index(['visit'])['visit'] == "followup_1y").any()

--- a/scripts/reporting/unuploaded_scans_check
+++ b/scripts/reporting/unuploaded_scans_check
@@ -40,6 +40,9 @@ def main(args):
     # Remove non-standard scans and make scan type simpler to allow for later comparison with Redcap
     xnat = xnat[xnat['scan_type'].str.contains("^ncanda-+", na=False) & ~xnat['scan_type'].str.contains("-bad$", na=False)]
     xnat.loc[:, 'scan_type'] = xnat.scan_type.apply(simplify_scan_name)
+
+    # Null out any whitespace-only notes and create an indicator variable for scan note presence
+    xnat.loc[xnat['scan_note'].str.contains(r'^\s*$', na=False), 'scan_note'] = np.nan  
     xnat['has_note'] = xnat['scan_note'].notnull()
 
     scan_fields = ['mri_series_t1', 'mri_series_t2', 'mri_series_dti6b500pepolar',


### PR DESCRIPTION
The primary script is `duplicate_scans_check`. One thing of note is that in order to make an independent check, it re-implements the XNAT-to-Redcap-event logic in a slightly different way.

This PR also implements fixes requested for #289.