### PR TITLE
Fix DAG assignment for the Import project

### DIFF
--- a/scripts/import/laptops/csv2redcap
+++ b/scripts/import/laptops/csv2redcap
@@ -26,7 +26,10 @@ parser.add_argument("-f", "--force-update",
                     help="Force updates even when records are already marked "
                          "'Complete'",
                     action="store_true")
-parser.add_argument( "--project", help="REDCAP project (import_laptops, import_webcnp, or data_entry)", default="import_laptops" )
+parser.add_argument("--project",
+                    help="REDCAP project to import the CSV into",
+                    choices=["import_laptops", "import_webcnp", "data_entry"],
+                    default="import_laptops")
 parser.add_argument("--data-access-group",
                     help="REDCap project data access group that the imported "
                          "data should be assigned to.",
@@ -34,16 +37,18 @@ parser.add_argument("--data-access-group",
 parser.add_argument("csvfile",
                     nargs='+',
                     help="Input .csv file.")
-parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
-
-parser.add_argument("-t","--time-log-dir",
+parser.add_argument("-p", "--post-to-github",
+                    help="Post all issues to GitHub instead of stdout.",
+                    action="store_true")
+parser.add_argument("-t", "--time-log-dir",
                     help="If set then time logs are written to that directory",
                     action="store",
                     default=None)
 
 args = parser.parse_args()
 
-slog.init_log(args.verbose, args.post_to_github,'NCANDA Import', 'import-laptops-csv2redcap', args.time_log_dir)
+slog.init_log(args.verbose, args.post_to_github, 'NCANDA Import',
+              'import-laptops-csv2redcap', args.time_log_dir)
 slog.startTimer1()
 
 # Open connection to REDCap server
@@ -101,16 +106,20 @@ def process_file(fname):
     # Make list of dicts for REDCap import
     record_list = []
     for key, row in data.iterrows():
-        if 'record_id' not in  row.index :
-            justFile= os.path.basename(fname) 
-            slog.info( str(args.data_access_group) + "-" + hashlib.sha1(fname).hexdigest()[0:6], "'record_id' is not defined in file '" + justFile + "'!",
-                   cmd = " ".join(sys.argv),
-                   file_name = fname,
-                   project=args.project)
+        if 'record_id' not in row.index:
+            justFile = os.path.basename(fname)
+            slog.info(
+                "%s-%s" % (str(row['redcap_data_access_group']),
+                           hashlib.sha1(fname).hexdigest()[0:6]),
+                "'record_id' is not defined in file '%s'!" % justFile,
+                cmd=" ".join(sys.argv),
+                file_name=fname,
+                project=args.project
+            )
             return False
- 
+
         row['record_id'] = re.sub('(#|&|\+|\')', '?', row['record_id'])
- 
+
         record_id = row['record_id']
         if complete_field:
             if record_id in existing_data.index.tolist():
@@ -127,7 +136,7 @@ def process_file(fname):
         import_response = project.import_records(record_list, overwrite='overwrite')
 
     except Exception as err_msg: 
-        justFile= os.path.basename(fname)
+        justFile = os.path.basename(fname)
         slog.info( str(args.data_access_group) + "-" + hashlib.sha1(fname + str(err_msg)).hexdigest()[0:6], "Upload error to redcap for file " + justFile,
                    error_msg=str(err_msg),
                    record_list =str(record_list), 
@@ -164,7 +173,7 @@ def process_file(fname):
     return True
 
 # Process all files from the command line
-uploaded = 0 
+uploaded = 0
 records = 0
 uploadedFlag=True
 for f in args.csvfile:

--- a/scripts/import/laptops/csv2redcap
+++ b/scripts/import/laptops/csv2redcap
@@ -30,14 +30,7 @@ parser.add_argument("--project",
                     help="REDCAP project to import the CSV into",
                     choices=["import_laptops", "import_webcnp", "data_entry"],
                     default="import_laptops")
-parser.add_argument("--data-access-group",
-                    help="REDCap project data access group that the imported "
-                    "data should be assigned to *if and only if* the "
-                    "imported file doesn't specify otherwise.",
-                    default=None)
-parser.add_argument("--ignore-file-dag",
-                    help="Even if file contains a DAG designation, ignore it.",
-                    action="store_true")
+
 parser.add_argument("--update-dag-only",
                     help="Ignore any file content except DAG designation. "
                     "(Useful for fixing incorrectly applied DAGs.)",
@@ -52,6 +45,20 @@ parser.add_argument("-t", "--time-log-dir",
                     help="If set then time logs are written to that directory",
                     action="store",
                     default=None)
+
+# Either get DAG via an explicit argument, or receive explicit instruction that
+# DAG should be derived from the file, but not both
+group_dag = parser.add_mutually_exclusive_group()
+group_dag.add_argument("--data-access-group",
+                       help="REDCap project data access group that the "
+                       "imported data should be assigned to",
+                       default=None)
+group_dag.add_argument("--use-file-dag",
+                       help="Infer the data access group from the contents of "
+                       "the file. If the DAG cannot be inferred, the script"
+                       "will fail.",
+                       default=False,
+                       action="store_true")
 
 args = parser.parse_args()
 
@@ -94,11 +101,23 @@ def process_file(fname):
 
     # Bring original "siteid" column back to assign each record to the correct
     # data access group
-    if args.ignore_file_dag:
+    if args.data_access_group:
         site = args.data_access_group
+    elif args.use_file_dag:
+        site = get_dag_from_df(data, verbose=args.verbose)
+        if not site:
+            slog.info(
+                (hashlib.sha1('import-laptops-csv2redcap / use-file-dag {}'
+                              .format(os.path.basename(fname)))
+                 .hexdigest()[0:6]),
+                "ERROR: Site could not be inferred from file",
+                instruction="You should re-run csv2redcap with a manually "
+                            "specified DAG in --data-access-group",
+                filename=fname,
+            )
+            return False
     else:
-        site = get_dag_from_df(data, default_site=args.data_access_group,
-                               verbose=args.verbose)
+        site = None
     data['redcap_data_access_group'] = site
 
     # Get "complete" field of existing records so we can protect "Complete"
@@ -147,12 +166,6 @@ def process_file(fname):
             if args.verbose:
                 print "%s assigned to %s" % (record_id,
                                              row['redcap_data_access_group'])
-        if ((args.data_access_group != row['redcap_data_access_group']) and
-                args.verbose):
-            print "WARNING: DAG is %s, but --data-access-group was %s" % (
-                site,
-                args.data_access_group,
-            )
 
         # Prune and convert to dict
         record = dict(row.dropna().apply(lambda s: re.sub('&quot;', '""', s)))
@@ -228,10 +241,16 @@ def get_dag_from_df(df, dag_field_regex=r'_[sS]ite\d?', site_lookup=None,
                                                              len(varnames))
         return None
     dag_varname = varnames[0]
+
+    # .item() ensures that the *content* of the cell is returned, not a Series
+    # with a single column
     if preserve_invalid_dag:
-        return df[dag_varname].map(lambda x: site_lookup.get(x, x))
+        return df[dag_varname].map(lambda x: site_lookup.get(x, x)).item()
     else:
-        return df[dag_varname].map(lambda x: site_lookup.get(x, default_site))
+        return (df[dag_varname]
+                .map(lambda x: site_lookup.get(x, default_site))
+                .item())
+
 
 # Process all files from the command line
 uploaded = 0
@@ -239,7 +258,6 @@ records = 0
 uploadedFlag=True
 for f in args.csvfile:
     uploadedFlag &= process_file(f)
-    
 
 # Print failures
 if len(failed) > 0:

--- a/scripts/import/laptops/csv2redcap
+++ b/scripts/import/laptops/csv2redcap
@@ -32,8 +32,16 @@ parser.add_argument("--project",
                     default="import_laptops")
 parser.add_argument("--data-access-group",
                     help="REDCap project data access group that the imported "
-                         "data should be assigned to.",
+                    "data should be assigned to *if and only if* the "
+                    "imported file doesn't specify otherwise.",
                     default=None)
+parser.add_argument("--ignore-file-dag",
+                    help="Even if file contains a DAG designation, ignore it.",
+                    action="store_true")
+parser.add_argument("--update-dag-only",
+                    help="Ignore any file content except DAG designation. "
+                    "(Useful for fixing incorrectly applied DAGs.)",
+                    action="store_true")
 parser.add_argument("csvfile",
                     nargs='+',
                     help="Input .csv file.")
@@ -86,8 +94,12 @@ def process_file(fname):
 
     # Bring original "siteid" column back to assign each record to the correct
     # data access group
-    if args.data_access_group:
-        data['redcap_data_access_group'] = args.data_access_group
+    if args.ignore_file_dag:
+        site = args.data_access_group
+    else:
+        site = get_dag_from_df(data, default_site=args.data_access_group,
+                               verbose=args.verbose)
+    data['redcap_data_access_group'] = site
 
     # Get "complete" field of existing records so we can protect "Complete"
     # records from overwriting
@@ -128,6 +140,21 @@ def process_file(fname):
                         print "Forcing update of 'Complete' record", record_id
                     else:
                         continue
+
+        # DAG stuff
+        if args.update_dag_only:
+            row = row[['record_id', 'redcap_data_access_group']]
+            if args.verbose:
+                print "%s assigned to %s" % (record_id,
+                                             row['redcap_data_access_group'])
+        if ((args.data_access_group != row['redcap_data_access_group']) and
+                args.verbose):
+            print "WARNING: DAG is %s, but --data-access-group was %s" % (
+                site,
+                args.data_access_group,
+            )
+
+        # Prune and convert to dict
         record = dict(row.dropna().apply(lambda s: re.sub('&quot;', '""', s)))
         record_list.append(record)
 
@@ -171,6 +198,40 @@ def process_file(fname):
         failed.append(fname)
 
     return True
+
+
+def get_dag_from_df(df, dag_field_regex=r'_[sS]ite\d?', site_lookup=None,
+                      default_site=None, preserve_invalid_dag=False,
+                      verbose=False):
+    """
+    If present, extract and translate the content of the DAG field in the file.
+
+    By default, the DAG field is expected to be a single lowercase letter to be
+    converted to one of NCANDA's five sites.
+
+    If the DAG field is not found in site_lookup, the result is default_site
+    or, if preserve_invalid_dag is set, the original value.
+    """
+    if not site_lookup:
+        site_lookup = {
+            'a': 'upmc',
+            'b': 'sri',
+            'c': 'duke',
+            'd': 'ohsu',
+            'e': 'ucsd',
+        }
+
+    varnames = [col for col in df.columns if re.search(dag_field_regex, col)]
+    if len(varnames) != 1:
+        if verbose:
+            print "Regex %s found %d columns, expected 1" % (dag_field_regex,
+                                                             len(varnames))
+        return None
+    dag_varname = varnames[0]
+    if preserve_invalid_dag:
+        return df[dag_varname].map(lambda x: site_lookup.get(x, x))
+    else:
+        return df[dag_varname].map(lambda x: site_lookup.get(x, default_site))
 
 # Process all files from the command line
 uploaded = 0

--- a/scripts/import/laptops/csv2redcap
+++ b/scripts/import/laptops/csv2redcap
@@ -88,6 +88,8 @@ failed = []
 
 
 # Process one file.
+# FIXME: The contents of the function depend on the `args` variable from the
+#        top-level scope. (As well as the actually declared globals.)
 def process_file(fname):
     # Read input file
     global records
@@ -205,8 +207,8 @@ def process_file(fname):
         uploaded += import_response['count']
         records += len(data)
         if args.verbose:
-            print "Successfully uploaded %d/%d records to REDCap." % \
-                  (import_response['count'], len(data))
+            print ("%s: Successfully uploaded %d/%d records to REDCap.") % \
+                  (fname, import_response['count'], len(data))
     else:
         failed.append(fname)
 

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -89,6 +89,9 @@ parser.add_argument("--omit-svn-update",
                     action="store_true",
                     default=False)
 
+# NOTE: Although most of the harvester logic is abstracted into functions, note
+#       that most functions rely on the `args` variable to be available from
+#       the calling scope
 args = parser.parse_args()
 
 # Setup logging
@@ -120,10 +123,23 @@ with open(os.path.join(sibis_config, 'special_cases.yml'), 'r') as fi:
     fi.close()
 
 if harvster_setting: 
-    ignore_data = harvster_setting.get('ignore')
-else : 
+    ignore_data = harvster_setting.get('ignore', {})
+    infer_dag_since = harvster_setting.get('infer_dag_since', {})
+    for laptop in infer_dag_since:
+        try:
+            infer_dag_since[laptop] = datetime.datetime.strptime(
+                infer_dag_since[laptop],
+                r'%Y-%m-%d')
+        except ValueError:
+            print("Laptop %s has a DAG inference setting, but invalid value"
+                  " %s; should be YYYY-MM-DD.").format(laptop,
+                                                       infer_dag_since[laptop])
+            infer_dag_since[laptop] = None
+else:
+    # FIXME: Should condition on args.verbose?
     print "Warning: harvester specific settings not defined!"
     ignore_data = dict()
+    infer_dag_since = dict()
 
 def run_converter(site, subject_label, command,verbose):
     """
@@ -187,8 +203,6 @@ def run_converter(site, subject_label, command,verbose):
                         # later find some of the fields in non-LimeSurvey
                         # imports correspond to the regex that csv2redcap uses
                         # to identify the DAG-carrying field.
-                        if site != "ucsd":
-                            command_array += ["--ignore-file-dag"]
                         
                         if verbose: 
                             print "Running: " + ' '.join(command_array)
@@ -412,7 +426,22 @@ for file in updated_files:
                 print "Skipping ", file
             continue 
  
-    handle_file_update( file , args.verbose)
+    # Check if DAG should be derived from the file path, or inferred from the
+    # file itself (much later, at csv2redcap invocation)
+    infer_dag = False
+    if laptop in infer_dag_since:
+        infer_dag_start = infer_dag_since[laptop]
+        if infer_dag_start:
+            # check if file's Last Modified is after the DAG inference start
+            last_modified = datetime.datetime.fromtimestamp(
+                os.path.getmtime(file))
+            if infer_dag_start <= last_modified:
+                infer_dag = True
+        else:
+            # FIXME: Should this fail instead because the value *should* be a date?
+            infer_dag = True
+
+    handle_file_update(file, args.verbose)
 
 slog.takeTimer1("script_time","{'records': " + str(len(updated_files)) + "}")
 

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -173,6 +173,22 @@ def run_converter(site, subject_label, command,verbose):
                             command_array += ["-t", args.time_log_dir]
 
                         command_array += ['--data-access-group', site, fi]
+
+                        # NOTE: As of April 2018, all LimeSurvey files are
+                        # collected on a UCSD server and uploaded via a UCSD
+                        # SVN account (ucsd49), which induces harvester to
+                        # assume all such records' DAG should be UCSD. For
+                        # those cases, we want csv2redcap to look into the file
+                        # and select the DAG based on the relevant variable if
+                        # possible, overruling --data-access-group.
+                        #
+                        # For other cases, though, we still want to respect the
+                        # uploading laptop - in case, for instance, that we
+                        # later find some of the fields in non-LimeSurvey
+                        # imports correspond to the regex that csv2redcap uses
+                        # to identify the DAG-carrying field.
+                        if site != "ucsd":
+                            command_array += ["--ignore-file-dag"]
                         
                         if verbose: 
                             print "Running: " + ' '.join(command_array)

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -141,7 +141,7 @@ else:
     ignore_data = dict()
     infer_dag_since = dict()
 
-def run_converter(site, subject_label, command,verbose):
+def run_converter(site, subject_label, command, verbose, infer_dag=False):
     """
     Conversion tool.
 
@@ -188,22 +188,27 @@ def run_converter(site, subject_label, command,verbose):
                         if args.time_log_dir:
                             command_array += ["-t", args.time_log_dir]
 
-                        command_array += ['--data-access-group', site, fi]
-
                         # NOTE: As of April 2018, all LimeSurvey files are
                         # collected on a UCSD server and uploaded via a UCSD
                         # SVN account (ucsd49), which induces harvester to
                         # assume all such records' DAG should be UCSD. For
                         # those cases, we want csv2redcap to look into the file
                         # and select the DAG based on the relevant variable if
-                        # possible, overruling --data-access-group.
+                        # possible, rather than use --data-access-group.
                         #
-                        # For other cases, though, we still want to respect the
-                        # uploading laptop - in case, for instance, that we
-                        # later find some of the fields in non-LimeSurvey
-                        # imports correspond to the regex that csv2redcap uses
-                        # to identify the DAG-carrying field.
-                        
+                        # Whether DAG should be inferred is based on the
+                        # setting file, section harvester::infer_dag_since,
+                        # which is read at the top of this file. The actual
+                        # logic is executed at the bottom of this file, prior
+                        # to the handle_file_update call.
+                        if infer_dag:
+                            command_array += ['--use-file-dag']
+                        else:
+                            command_array += ['--data-access-group', site]
+
+                        # Finally, add the file to the command
+                        command_array += [fi]
+
                         if verbose: 
                             print "Running: " + ' '.join(command_array)
 
@@ -238,7 +243,8 @@ def run_converter(site, subject_label, command,verbose):
 #
 # Function: hand file to correct converter
 #
-def handle_file( path, site, filename, verbose):
+def handle_file(path, site, filename, verbose, infer_dag=False):
+    # NOTE: infer_dag is only passed along for LimeSurvey files
     # Prepare option for overwriting
     if args.overwrite:
         overwrite = ["--overwrite"]
@@ -254,7 +260,7 @@ def handle_file( path, site, filename, verbose):
     # Is this a LimeSurvey file?
     if re.match( '^survey.*\.csv$', filename ):
         # Never post to github as ou otherwise get two error messages - one from harvester and one from lime2csv 
-        run_converter( site, subject_label, [ os.path.join( bindir, "lime2csv" ) ] + overwrite + post_to_github + [ path, os.path.join(outdir, site, "limesurvey" ) ], verbose )
+        run_converter( site, subject_label, [ os.path.join( bindir, "lime2csv" ) ] + overwrite + post_to_github + [ path, os.path.join(outdir, site, "limesurvey" ) ], verbose, infer_dag=infer_dag)
     # Is this a Stroop file (Note: the "_100SD-" is signifigant as some MRI
     # Stroop files will include "_100SDMirror" in the filename)?
     elif re.match('^NCANDAStroopMtS_3cycles_7m53stask_100SD-[^/]*\.txt$', filename):
@@ -302,7 +308,9 @@ def handle_file( path, site, filename, verbose):
 #
 # Function: handle updated file by dispatching to the correct subhandler
 #
-def handle_file_update( path, verbose ):
+def handle_file_update(path, verbose, infer_dag=False):
+    # FIXME: For special DAG handling, should take an additional
+    # argument to pass along to handle_file
     # First, let's get the site ID from the path
     match_site = re.search( 'ncanda/([A-Za-z]*)[^/]*/(.*)', path )
 
@@ -314,7 +322,7 @@ def handle_file_update( path, verbose ):
             return
 
         filename = re.search( '(.*)/([^/].*)', path ).group( 2 );
-        handle_file( path, site, filename, verbose)
+        handle_file(path, site, filename, verbose, infer_dag=infer_dag)
                             
 #
 # Callback: catch files added and updated since last svn update
@@ -441,7 +449,7 @@ for file in updated_files:
             # FIXME: Should this fail instead because the value *should* be a date?
             infer_dag = True
 
-    handle_file_update(file, args.verbose)
+    handle_file_update(file, args.verbose, infer_dag=infer_dag)
 
 slog.takeTimer1("script_time","{'records': " + str(len(updated_files)) + "}")
 


### PR DESCRIPTION
See #285 for the description of the problem. The fix is entirely in b38a0e1; the other commit consists of incidental whitespace edits.

This introduces the following two changes:

* `--data-access-group` is now only advisory unless `--ignore-file-dag` is passed. (harvester will now pass it unless the file comes from UCSD because UCSD now sometimes uploads other sites' files, too.)
* `--update-dag-only` is introduced to facilitate fixing DAGs that were previously assigned incorrectly. For example, to fix the DAG mis-assignments for the past four months, we could now run:
  ```bash
  for file in /fs/storage/laptops/imported/ucsd/limesurvey/{youthreport{1,1b,2},parentreport,lssaga1_{youth,parent},mrireport,myy,plus,recq}/*2018*.csv; do
    /sibis-software/ncanda-data-integration/scripts/import/laptops/csv2redcap \
      --verbose --data-access-group ucsd --update-dag-only $file
  done
  ```

  This will update the DAG to the site listed in `${form}_site\d?$` field of the file if that field can be found (and no other field fits that bill), otherwise it will keep the DAG to UCSD.

  (Why a regex instead of a firm designation? That's because there's no rhyme or reason to the way the forms are naming these fields:

  ```python
  {'lssaga1_parent': ['lssaga1_parent_site'],
   'lssaga1_youth': ['lssaga1_youth_site'],
   'mrireport': ['mrireport_site'],
   'myy': ['myy_site'],
   'parentreport': ['parentreport_site3'],
   'plus': ['plus_site'],
   'sleepeve': ['sleepeve_site'],
   'sleepmor': ['sleepmor_site'],
   'sleeppre': ['sleeppre_site'],
   'youthreport1': ['youthreport1_site2'],
   'youthreport1b': ['youthreport1b_site2'],
   'youthreport2': ['youthreport2_site']}
  ```

  We can't change this easily because that would require changing the datadicts.)