### PR TITLE
Get a table of processing status for all LS files that fit criteria

### DIFF
--- a/scripts/reporting/find_limesurvey_status
+++ b/scripts/reporting/find_limesurvey_status
@@ -12,16 +12,16 @@ Sample uses:
 - Retrieve all raw *and* processed 2018 files for all subjects that begin with
   E-00207:
 
-    ./find_pipeline_status all --subject='E-00207-*' --date="2018*"
+    ./find_limesurvey_status all --subject='E-00207-*' --date="2018*"
 
 - Retrieve only processed youthreport1 files for subjects beginning with
   A-00002:
 
-    ./find_pipeline_status proc --subject='A-00002-*' --form-name='youthreport1'
+    ./find_limesurvey_status proc --subject='A-00002-*' --form-name='youthreport1'
 
 - Get all raw files collected between April 10 and April 19, 2018:
 
-    ./find_pipeline_status.py raw --date="2018041?"
+    ./find_limesurvey_status.py raw --date="2018041?"
 
 Room for improvement:
 

--- a/scripts/reporting/find_pipeline_status
+++ b/scripts/reporting/find_pipeline_status
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Get a table of processing status for all LimeSurvey files that fit criteria.
+
+Note that while the criteria allow for glob-like use, it's Python glob, not
+bash glob - so asterisk works as expected, but options in curly brackets do
+not!
+
+Sample uses:
+
+- Retrieve all raw *and* processed 2018 files for all subjects that begin with
+  E-00207:
+
+    ./find_pipeline_status all --subject='E-00207-*' --date="2018*"
+
+- Retrieve only processed youthreport1 files for subjects beginning with
+  A-00002:
+
+    ./find_pipeline_status proc --subject='A-00002-*' --form-name='youthreport1'
+
+- Get all raw files collected between April 10 and April 19, 2018:
+
+    ./find_pipeline_status.py raw --date="2018041?"
+
+Room for improvement:
+
+- Use *only* correct matching IDs and dates extracted from files
+- Correctly identify lssaga_youth vs. _parent
+- Fuzzy-match IDs
+- Use a sliding time window
+"""
+from glob import glob
+import pandas as pd
+import os
+import sys
+import fire
+from functools import wraps
+from limesurvey_utils import (limesurvey_number_to_name,
+                              limesurvey_name_to_number,
+                              limesurvey_name_glob_to_names,
+                              limesurvey_name_glob_to_numbers,
+                              get_within_file_info,
+                              get_import_url)
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)
+
+
+def find_processed_limesurvey_forms(subject='*', form_name='*', date='*',
+                                    path='/fs/storage/laptops/imported'):
+    """
+    Given glob information, get a DataFrame of matching processed LS files
+    """
+    date = str(date)
+    if len(date) == 8 and "-" not in date:
+        date = "%s-%s-%s" % (date[0:4], date[4:6], date[6:8])
+    glob_pattern = "%s/*/limesurvey/%s/%s-%s.csv" % (
+        path, form_name, subject, date
+    )
+    matched_files = glob(glob_pattern)
+    files = pd.DataFrame({'proc_path': matched_files,
+                          'proc_site': [f.split('/')[-4]
+                                        for f in matched_files],
+                          'proc_form': [f.split('/')[-2]
+                                        for f in matched_files],
+                          'proc_name': [os.path.basename(f)
+                                        for f in matched_files]})
+    if files.empty:
+        return files
+    files[['import_id', 'proc_subj', 'proc_date']] = (files['proc_name']
+                                                      .str.extract(
+        r'(([A-Z]-\d{5}-[MFTX]-\d)-(\d{4}-\d{2}-\d{2}))'
+    ))
+    files['proc_date'] = files['proc_date'].str.replace('-', '')
+    return (files.sort_values(['proc_date'])
+            .pipe(get_import_url))
+
+
+def find_raw_limesurvey_uploads(subject='*', form_number='*', date='*',
+                                path='/fs/storage/laptops/ncanda'):
+    """
+    Given glob information, get a DataFrame of matching raw LS files
+    """
+    if date != '*':
+        # Should probably try to parse it?
+        # assert len(date) == 8
+        pass
+
+    glob_pattern = "%s/*/%s[-_]%s/survey_%s*.csv" % (
+        path, subject, date, form_number
+    )
+    matched_files = glob(glob_pattern)
+    files = pd.DataFrame({'raw_path': matched_files,
+                          'raw_name': [os.path.basename(f)
+                                       for f in matched_files]})
+    if files.empty:
+        return files
+    files['svn_origin'] = files['raw_path'].str.split('/').str.get(-3)
+    files['raw_site'] = files['svn_origin'].str.extract('([a-z]+)')
+    files[['raw_ls_number', 'raw_subj', 'raw_date']] = (files['raw_name']
+                                                        .str.extract(
+        r'survey_(\d{5,6})_subjid_([A-Z]-\d{5}-[MFTX]-\d)[_-](\d{8})'
+    ))
+    nonnull_ls_number = files['raw_ls_number'].notnull()
+    files.loc[nonnull_ls_number,
+              'raw_form'] = (files.loc[nonnull_ls_number, 'raw_ls_number']
+                             .apply(limesurvey_number_to_name, short=True,
+                                    raise_error=False))
+    # 4. Within-file ID (main)
+    # 5. Within-file ID (others)
+    # 6. Within-file date (main)
+    # 7. Within-file date (others)
+    # return files.raw_path.apply(get_within_file_info, is_lssaga=True)
+    return files.sort_values(['raw_date'])
+
+
+def find_raw2processed_status(subject='*',
+                              form_number=None,
+                              form_name=None,
+                              date='*',
+                              raw_path='/fs/storage/laptops/ncanda',
+                              processed_path='/fs/storage/laptops/imported',
+                              droptests=True,
+                              trim=True,
+                              # FIXME: The following options should either be
+                              # documented or removed (or, better still,
+                              # extracted to a different function that inherits
+                              # from this one)
+                              showunmatched=False,
+                              orphaned=False,
+                              unharvested=False,):
+    # First, need to convert the two ways of getting form type to be compatible
+    if not form_number and not form_name:
+        form_numbers = ['*']
+        form_names = ['*']
+    elif form_number:  # FIXME: Assuming exact number, which might be incorrect
+        form_numbers = [form_number]
+        form_names = [limesurvey_number_to_name(form_number, short=True)]
+    elif form_name:
+        form_numbers = limesurvey_name_glob_to_numbers(form_name)
+        form_names = limesurvey_name_glob_to_names(form_name)
+
+    raw_dfs = [find_raw_limesurvey_uploads(subject, number, date, raw_path)
+               for number in form_numbers]
+    proc_dfs = [find_processed_limesurvey_forms(subject, name, date,
+                                                processed_path)
+                for name in form_names]
+
+    raw_df = pd.concat(raw_dfs, axis=0)
+    proc_df = pd.concat(proc_dfs, axis=0)
+
+    # FIXME: With more introspection, we'll want to be merging on different IDs
+    df_all = (pd.merge(raw_df, proc_df,
+                       how='outer',
+                       left_on=['raw_subj', 'raw_date', 'raw_form'],
+                       right_on=['proc_subj', 'proc_date', 'proc_form']))
+    df_all['subj'] = df_all.apply(
+        lambda x: x.raw_subj if not pd.isnull(x.raw_subj) else x.proc_subj,
+        axis=1)
+    df_all['date'] = df_all.apply(
+        lambda x: x.raw_date if not pd.isnull(x.raw_subj) else x.proc_date,
+        axis=1)
+    df_all['form'] = df_all.apply(
+        lambda x: x.raw_form if not pd.isnull(x.raw_subj) else x.proc_form,
+        axis=1)
+    df_all = df_all.dropna(subset=['subj'])
+    if droptests:
+        df_all = df_all.loc[~df_all['subj'].str.contains('[TX]')]
+    df_all = (df_all
+              .drop(columns=['raw_subj', 'proc_subj',
+                             'raw_date', 'proc_date',
+                             'raw_form', 'proc_form', ])
+              .set_index(['subj', 'date', 'form'])
+              .sort_index())
+
+    # If only interested in problem entries
+    unharvested_idx = df_all['url'].isnull()
+    noparent_idx = df_all['raw_path'].isnull()
+
+    if showunmatched or (orphaned and unharvested):
+        df_all = df_all.loc[unharvested_idx | noparent_idx]
+    elif orphaned:
+        df_all = df_all.loc[noparent_idx]
+    elif unharvested:
+        df_all = df_all.loc[unharvested_idx]
+
+    if trim:
+        return df_all[['raw_path', 'url']]
+    else:
+        return df_all
+
+
+if __name__ == "__main__":
+    # Set display properties
+    # *_path often exceeds max_colwidth -> remove that limitation
+    pd.set_option('display.max_colwidth', -1)
+    pd.set_option('display.max_rows', None)
+
+    # Modify the functions for proper str output
+    def __str_decorator(fn):
+        """
+        Strip objects returned to Python Fire to __str__.
+
+        (Otherwise, Fire would show object content + docstring + properties.)
+        """
+        @wraps(fn)  # to preserve fn.__name__ - inessential otherwise
+        def stringiated_fn(*args, **kwargs):
+            """
+            Any fn, just with __str__ called to its output
+            """
+            return fn(*args, **kwargs).__str__
+        return stringiated_fn
+
+    # Modify the functions for CSV output
+    def __csv_decorator(fn):
+        """
+        Apply .to_csv to object returned by function
+        """
+        @wraps(fn)  # to preserve fn.__name__ - inessential otherwise
+        def csvfied_fn(*args, **kwargs):
+            """
+            Any fn, just with .to_csv() called to its output
+            """
+            return fn(*args, **kwargs).to_csv(sys.stdout)
+        return csvfied_fn
+
+    fns = [find_raw_limesurvey_uploads,
+           find_processed_limesurvey_forms,
+           find_raw2processed_status, ]
+    fns_str = {fn.__name__: __str_decorator(fn) for fn in fns}
+    fns_csv = {fn.__name__: __csv_decorator(fn) for fn in fns}
+
+    # Register the modified functions
+    fire.Fire({
+        'all': fns_str['find_raw2processed_status'],
+        'all_csv': fns_csv['find_raw2processed_status'],
+        'all_df': find_raw2processed_status,
+        'raw': fns_str['find_raw_limesurvey_uploads'],
+        'raw_csv': fns_csv['find_raw_limesurvey_uploads'],
+        'raw_df': find_raw_limesurvey_uploads,
+        'proc': fns_str['find_processed_limesurvey_forms'],
+        'proc_csv': fns_csv['find_processed_limesurvey_forms'],
+        'proc_df': find_processed_limesurvey_forms,
+    })

--- a/scripts/reporting/find_pipeline_status
+++ b/scripts/reporting/find_pipeline_status
@@ -29,6 +29,7 @@ Room for improvement:
 - Correctly identify lssaga_youth vs. _parent
 - Fuzzy-match IDs
 - Use a sliding time window
+- Fail gracefully when something cannot be retrieved and/or found
 """
 from glob import glob
 import pandas as pd
@@ -36,15 +37,18 @@ import os
 import sys
 import fire
 from functools import wraps
+import sibispy
 from limesurvey_utils import (limesurvey_number_to_name,
                               limesurvey_name_to_number,
                               limesurvey_name_glob_to_names,
                               limesurvey_name_glob_to_numbers,
                               get_within_file_info,
-                              get_import_url)
+                              get_import_url,
+                              get_completion_status_in_redcap,
+                              get_completion_status_for_pipe)
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
-warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)
+# warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)
 
 
 def find_processed_limesurvey_forms(subject='*', form_name='*', date='*',
@@ -73,8 +77,12 @@ def find_processed_limesurvey_forms(subject='*', form_name='*', date='*',
         r'(([A-Z]-\d{5}-[MFTX]-\d)-(\d{4}-\d{2}-\d{2}))'
     ))
     files['proc_date'] = files['proc_date'].str.replace('-', '')
-    return (files.sort_values(['proc_date'])
-            .pipe(get_import_url))
+    final_df = get_import_url(files.sort(['proc_date']))
+    final_df = get_completion_status_for_pipe(final_df, import_api)
+    return final_df
+    # sort_values and pipe not present yet in pandas 0.14
+    # return (files.sort_values(['proc_date'])
+    #         .pipe(get_import_url))
 
 
 def find_raw_limesurvey_uploads(subject='*', form_number='*', date='*',
@@ -86,6 +94,8 @@ def find_raw_limesurvey_uploads(subject='*', form_number='*', date='*',
         # Should probably try to parse it?
         # assert len(date) == 8
         pass
+    # If date contains dashes, that's no bueno for raw files -> remove
+    date = date.replace('-', '')
 
     glob_pattern = "%s/*/%s[-_]%s/survey_%s*.csv" % (
         path, subject, date, form_number
@@ -112,7 +122,8 @@ def find_raw_limesurvey_uploads(subject='*', form_number='*', date='*',
     # 6. Within-file date (main)
     # 7. Within-file date (others)
     # return files.raw_path.apply(get_within_file_info, is_lssaga=True)
-    return files.sort_values(['raw_date'])
+    return files.sort(['raw_date'])
+    # return files.sort_values(['raw_date'])
 
 
 def find_raw2processed_status(subject='*',
@@ -151,10 +162,20 @@ def find_raw2processed_status(subject='*',
     proc_df = pd.concat(proc_dfs, axis=0)
 
     # FIXME: With more introspection, we'll want to be merging on different IDs
-    df_all = (pd.merge(raw_df, proc_df,
-                       how='outer',
-                       left_on=['raw_subj', 'raw_date', 'raw_form'],
-                       right_on=['proc_subj', 'proc_date', 'proc_form']))
+    if raw_df.empty and proc_df.empty:
+        return pd.DataFrame()
+    elif raw_df.empty:
+        # df_all = proc_df
+        return proc_df
+    elif proc_df.empty:
+        # df_all = raw_df
+        return raw_df
+    else:
+        df_all = (pd.merge(raw_df, proc_df,
+                           how='outer',
+                           left_on=['raw_subj', 'raw_date', 'raw_form'],
+                           right_on=['proc_subj', 'proc_date', 'proc_form']))
+
     df_all['subj'] = df_all.apply(
         lambda x: x.raw_subj if not pd.isnull(x.raw_subj) else x.proc_subj,
         axis=1)
@@ -168,9 +189,10 @@ def find_raw2processed_status(subject='*',
     if droptests:
         df_all = df_all.loc[~df_all['subj'].str.contains('[TX]')]
     df_all = (df_all
-              .drop(columns=['raw_subj', 'proc_subj',
-                             'raw_date', 'proc_date',
-                             'raw_form', 'proc_form', ])
+              .drop(axis=1,
+                    labels=['raw_subj', 'proc_subj',
+                            'raw_date', 'proc_date',
+                            'raw_form', 'proc_form', ])
               .set_index(['subj', 'date', 'form'])
               .sort_index())
 
@@ -186,12 +208,21 @@ def find_raw2processed_status(subject='*',
         df_all = df_all.loc[unharvested_idx]
 
     if trim:
-        return df_all[['raw_path', 'url']]
+        wanted_cols = ['raw_path', 'proc_path', 'status', 'url']
+        # TODO: Check if available
+        return df_all[wanted_cols]
     else:
         return df_all
 
 
 if __name__ == "__main__":
+    # Set up sibispy
+    session = sibispy.Session()
+    OFFLINE = True
+    import_api = None
+    if session.configure():
+        OFFLINE = False
+        import_api = session.connect_server('import_laptops')
     # Set display properties
     # *_path often exceeds max_colwidth -> remove that limitation
     pd.set_option('display.max_colwidth', -1)
@@ -209,7 +240,12 @@ if __name__ == "__main__":
             """
             Any fn, just with __str__ called to its output
             """
-            return fn(*args, **kwargs).__str__
+            output = fn(*args, **kwargs)
+            if type(output) == pd.DataFrame and output.empty:
+                # Don't print anything for an empty DataFrame
+                return None
+            else:
+                return output.__str__
         return stringiated_fn
 
     # Modify the functions for CSV output

--- a/scripts/reporting/limesurvey_utils.py
+++ b/scripts/reporting/limesurvey_utils.py
@@ -1,7 +1,7 @@
 """
 Tools for working with raw and processed LimeSurvey forms in NCANDA pipeline
 
-Primarily used by find_pipeline_status.
+Primarily used by find_limesurvey_status.
 
 FIXME:
 - Form number is not sufficient for identifying whether LSSAGA is Youth or Parent -- necessary to consult `_typeintertranslate`

--- a/scripts/reporting/limesurvey_utils.py
+++ b/scripts/reporting/limesurvey_utils.py
@@ -1,0 +1,176 @@
+"""
+Tools for working with raw and processed LimeSurvey forms in NCANDA pipeline
+
+Primarily used by find_pipeline_status.
+
+FIXME:
+- Form number is not sufficient for identifying whether LSSAGA is Youth or Parent -- necessary to consult `_typeintertranslate`
+"""
+import pandas as pd
+import numpy as np
+from fnmatch import fnmatch
+from itertools import chain
+
+def limesurvey_number_to_name(ls_number, lookup_df=None, short=True,
+                              raise_error=True):
+    if lookup_df is None:
+        lookup_df = get_ncanda_form_lookup(as_dataframe=True)
+    try:
+        return lookup_df.loc[str(ls_number),
+                             'short_name' if short else 'long_name']
+    except KeyError:
+        if raise_error:
+            raise
+        else:
+            return np.nan
+
+
+def limesurvey_name_to_number(ls_name, lookup_df=None):
+    if lookup_df is None:
+        lookup_df = (get_ncanda_form_lookup(as_dataframe=True)
+                     .reset_index()
+                     # .set_index('short_name' if short else 'long_name'))
+                     .set_index(['short_name', 'long_name']))
+
+    # MultiIndex here should guarantee that no matter whether the form name
+    # passed is short or long, it will successfully look up the corresponding
+    # form number.
+    return lookup_df.loc[ls_name, 'ls_number'].tolist()
+
+def limesurvey_name_short_to_long(ls_name, lookup_df=None):
+    if lookup_df is None:
+        lookup_df = get_ncanda_form_lookup(as_dataframe=True)
+    lookup_dict = dict(zip(lookup_df['short_name'], lookup_df['long_name']))
+    return lookup_dict.get(ls_name)
+
+def limesurvey_name_glob_to_names(ls_glob, lookup_df=None):
+    if lookup_df is None:
+        lookup_df = (get_ncanda_form_lookup(as_dataframe=True))
+    short_names = lookup_df['short_name'].tolist()
+    # fnmatch is the function internally used by glob
+    return list(set([x for x in short_names if fnmatch(x, ls_glob)]))
+
+
+def limesurvey_name_glob_to_numbers(ls_glob, lookup_df=None):
+    # form_names = limesurvey_name_glob_to_names(ls_glob, lookup_df)
+    # FIXME: lookup_df is presumed to be indexed in a particular way, but that
+    #   particular way is different for limesurvey_name_to_number and
+    #   limesurvey_number_to_name, so we cannot pass it to both
+    form_names = limesurvey_name_glob_to_names(ls_glob)
+    # using itertools.chain because limesurvey_name_to_number returns a list
+    return list(set(chain(*[limesurvey_name_to_number(x)
+                            for x in form_names])))
+
+
+def get_within_file_info(fname, is_lssaga=False):
+    df = pd.read_csv(fname, dtype=object)
+    main_id = df.filter(regex="subjid$")
+    # TODO: Process into a single array of IDs that are different from main
+    aux_ids = df.filter(regex="subjid.$").dropna()
+    main_date = df.filter(regex="[cC]ompleted$|^[dD]ate_").dropna()
+    # survey_date_fields = [ 'completed', 'date_started', 'date_last_action', 'date_interview']
+    if is_lssaga:
+        lssaga_type = pd.DataFrame({
+            'lssaga_type': [get_lssaga_type(df, raise_error=False)]
+        })
+    else:
+        lssaga_type = pd.DataFrame()
+    return pd.concat([main_date, main_id, aux_ids, lssaga_type], axis=1)
+
+
+def get_lssaga_type(df, raise_error=False):
+    try:
+        typeinter = str(df['typeinter'].ix[0])
+    except KeyError:
+        if raise_error:
+            raise
+        else:
+            return ''
+
+    if typeinter == '0':
+        lssaga_type = "_parent"
+    elif typeinter == '1':
+        lssaga_type = "_youth"
+    elif raise_error:
+        raise ValueError("typeinter is %s, expected '0' or '1'" % typeinter)
+    else:
+        lssaga_type = ''
+    return lssaga_type
+
+
+def get_import_url(df,
+                   base_url="https://ncanda.sri.com/redcap/redcap_v8.4.0/"
+                            "DataEntry/index.php?pid=6&&event_id=21"):
+    if 'proc_form' not in df.columns:
+        # Assume it's in index
+        df['proc_form'] = df.index.get_level_values('form')
+    df['form_long'] = df['proc_form'].apply(limesurvey_name_short_to_long)
+    df['url'] = (base_url + "&id=" + df['import_id']
+                 + '&page=' + df['form_long'])
+    df.drop(columns=['form_long', 'import_id'], inplace=True)
+    return df
+
+ 
+
+def get_ncanda_form_lookup(as_dataframe=True):
+    # Taken from ncanda-data-integration/scripts/import/laptops/lime2csv
+    # FIXME: Form number is not sufficient for identifying whether LSSAGA is
+    #   Youth or Parent -- necessary to consult `_typeintertranslate`
+    lookup_dict = {
+        # Baseline surveys:
+        '11584': ('youthreport1', 'youth_report_1'),
+        '12471': ('youthreport2', 'youth_report_2'),
+        '31627': ('parentreport', 'parent_report'),
+        # Original MRI Report
+        '32869': ('mrireport', 'mri_report'),
+        # Improved MRI Report with Y/N skip-outs
+        '29516': ('mrireport', 'mri_report'),
+        '75894': ('plus', 'participant_last_use_summary'),
+        # Six-month survey:
+        '54587': ('myy', 'midyear_youth_interview'),
+        # One year follow-up surveys:
+        '13947': ('youthreport1', 'youth_report_1'),
+        '72223': ('youthreport1b', 'youth_report_1b'),
+        '92874': ('youthreport2', 'youth_report_2'),
+        '21598': ('parentreport', 'parent_report'),
+        # One year follow-up SSAGA (each part has an old and a new version;
+        # new version has some modules hidden from interviewer, but should
+        # otherwise be the same as the old):
+        # FIXME: Should remove _youth / _parent, because that's not how these
+        #   forms work -- which type they are is judged from the content
+        '14134': ('lssaga1_parent', 'limesurvey_ssaga_part_1_parent'),
+        '82982': ('lssaga1_youth', 'limesurvey_ssaga_part_1_youth'),
+        '72261': ('lssaga1_youth', 'limesurvey_ssaga_part_1_youth'),  # modified on YR4
+        '81475': ('lssaga2_parent', 'limesurvey_ssaga_part_2_parent'),
+        '37237': ('lssaga2_youth', 'limesurvey_ssaga_part_2_youth'),
+        '91768': ('lssaga3_parent', 'limesurvey_ssaga_part_3_parent'),
+        '29231': ('lssaga3_youth', 'limesurvey_ssaga_part_3_youth'),
+        '12396': ('lssaga4_parent', 'limesurvey_ssaga_part_4_parent'),
+        '56922': ('lssaga4_youth', 'limesurvey_ssaga_part_4_youth'),
+        # Sleep surveys:
+        '29361': ('sleepeve', 'sleep_study_evening_questionnaire'),
+        '82312': ('sleepeve', 'sleep_study_evening_questionnaire'),
+        '96417': ('sleepmor', 'sleep_study_morning_questionnaire'),
+        '88371': ('sleeppre', 'sleep_study_presleep_questionnaire'),
+        '34495': ('sleeppre', 'sleep_study_presleep_questionnaire'),
+        # Recovery Forms
+        '67375': ('recq', 'recovery_questionnaire'),
+        # Longitudinal follow-up surveys: (mostly from YR2 to YR3)
+        '17895': ('youthreport1', 'youth_report_1'),  # Improved YR1
+        '11772': ('youthreport1b', 'youth_report_1b'),  # Improved YR1b
+        '25126': ('youthreport2', 'youth_report_2'),  # Improved YR2
+        '27974': ('parentreport', 'parent_report'),  # Improved Parent Report
+        '41833': ('mrireport', 'mri_report'),  # Improved MRI Report
+        '97714': ('plus', 'participant_last_use_summary'),  # Improved PLUS
+
+        # Longitudinal six-month survey: (should not need to be changed!)
+        '79454': ('myy', 'midyear_youth_interview'),
+    }
+    if as_dataframe:
+        lookup_df = pd.DataFrame.from_dict(lookup_dict, orient='index')
+        lookup_df.index.name = 'ls_number'
+        new_cols = ['short_name', 'long_name', 'latest']
+        lookup_df.columns = new_cols[0:len(lookup_df.columns)]
+        return lookup_df
+    else:
+        return lookup_dict


### PR DESCRIPTION
Uses [Python Fire](https://github.com/google/python-fire) under the hood, so it will not work in the current pipeline environment.

Sample uses:

- Retrieve all raw *and* processed 2018 files for all subjects that begin with
  E-00207:

    `./find_pipeline_status all --subject='E-00207-*' --date="2018*"`

- Retrieve only processed youthreport1 files for subjects beginning with
  A-00002:

    `./find_pipeline_status proc --subject='A-00002-*' --form-name='youthreport1'`

- Get all raw files collected between April 10 and April 19, 2018:

    `./find_pipeline_status.py raw --date="2018041?"`

Note that while the criteria allow for glob-like use, it's Python glob, not bash glob - so asterisk works as expected, but options in curly brackets do not!