### PR TITLE
Add warning about age-based MRI exclusions

### DIFF
--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -340,13 +340,21 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
 
     if not xnat_session_data:
         if today > visit_date_plusNd:
-            
-            error='Missing MRI for Subject with visit date.'
-            slog.info(redcap_visit_id,error,
-                          xnat_project_id=xnat_pid,
-                          xnat_subject_id=xnat_sid,
-                          visit_id=event,
-                          visit_date=visit_date)
+            # TODO: Check that today - date_of_birth doesn't fall into one of
+            # the exceptions (if subject is 23, 25, or 26)
+            error = 'Missing MRI for Subject with visit date.'
+            age = round(red2cas.days_between_dates(date_of_birth, visit_date) / 365.242, 2)
+            age_note = ("Participant age on visit date was %.2f. It is "
+                        "possible that scan wasn't acquired because protocol "
+                        "states that scans be skipped at ages 23, 25, and 26."
+                        % age)
+            slog.info(redcap_visit_id,
+                      error,
+                      xnat_project_id=xnat_pid,
+                      xnat_subject_id=xnat_sid,
+                      visit_id=event,
+                      visit_date=visit_date,
+                      age_note=age_note)
         return [None,True]
 
 


### PR DESCRIPTION
Initial foray into age-based MRI exclusion. This simply adds a warning to the "Missing MRI for Subject with visit date" error that this might be a protocol issue.

If we wish to avoid the error altogether, a principled way of doing so would be to add a section to `special_cases.yml` with ages to exclude, then compare to that.