### PR TITLE
[port-svn] Migrate from pysvn to svn

### DIFF
--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -13,11 +13,12 @@ import subprocess
 import sys
 
 from sibispy import sibislogger as slog
+from sibispy.svn import SibisSvnException, UpdateActionTypes
 import sibispy 
 
 import hashlib
 updated_files = []
-import pysvn
+
 import datetime 
 # Setup command line parser
 parser = argparse.ArgumentParser(description="Harvest incoming data files from "
@@ -102,7 +103,8 @@ session = sibispy.Session()
 if not session.configure() :
     sys.exit()
 
-if not session.connect_server('svn_laptop', True) : 
+svn_client = session.connect_server('svn_laptop', True)
+if not svn_client: 
     sys.exit()
 
 
@@ -324,14 +326,6 @@ def handle_file_update(path, verbose, infer_dag=False):
         filename = re.search( '(.*)/([^/].*)', path ).group( 2 );
         handle_file(path, site, filename, verbose, infer_dag=infer_dag)
                             
-#
-# Callback: catch files added and updated since last svn update
-#
-def notify( event_dict ):
-    global updated_files
-    if event_dict['kind'] == pysvn.node_kind.file:
-        if event_dict['action'] == pysvn.wc_notify_action.update_add or event_dict['action'] == pysvn.wc_notify_action.update_update or event_dict['action'] == pysvn.wc_notify_action.restore:
-            updated_files.append( event_dict['path'] )
 
 #
 # Main function: perform svn update and catch all resulting events
@@ -344,9 +338,17 @@ if not args.omit_svn_update:
     if args.verbose :
         print "Run svn update ..."
  
-    if not session.run_svn('update', callbackNotifyFct = notify) : 
+    svn_info = svn_client.info()
+
+    svn_updates = svn_client.update()
+    if len(svn_updates.errors) > 0:
         sys.exit(1)
 
+    svn_diff = svn_client.diff_path(revision=svn_info['entry_revision'])
+
+    for changed in svn_diff.files_changed():
+        updated_files.append(os.path.join(svndir, changed))
+        
     if args.verbose :
         print "... done " 
 
@@ -369,19 +371,17 @@ if args.last_week :
     dated_download =  "{" + str(date_last_week) + "}:{" + str(date_tomorrow) + "}"
 
 if dated_download : 
-    # Files that are added and deleted during the time period are now listed ! 
-    cmd ='cd {}; svn diff --no-auth-cache --username {} --password \'{}\' --summarize -r {} | grep -v "D     "  | tr " " "," | cut -d, -f8 | grep "\." | tr "\n" ","'.format( svndir, session.api['svn_laptop']['user'], session.api['svn_laptop']['password'], dated_download )
-    process = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-    out_std,out_err = process.communicate()
-    if out_err :
-        slog.info(hashlib.sha1('harvester' + out_err).hexdigest()[0:6],
+    # Files that are added and deleted during the time period are now listed !
+    try:
+        diff = svn_client.diff_path(revision=dated_download)
+        for d in diff.files_changed(include_deleted=False):
+            updated_files.append(os.path.join(svndir,d.path))
+
+    except SibisSvnException as ex:
+        slog.info(hashlib.sha1('harvester' + str(ex)).hexdigest()[0:6],
                   "ERROR: Failed to update files in range " + args.date + ". Continued without them!",
                   script='harvester',
-                  msg=out_err)
-    else :
-        if out_std :
-            for fName in out_std[:-1].split(',') :
-                updated_files.append(os.path.join(svndir,fName))               
+                  msg=str(ex))            
         
 elif args.file_to_upload:
     if not os.path.exists(args.file_to_upload):

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -4,6 +4,7 @@
 ##  See COPYING file distributed along with the ncanda-data-integration package
 ##  for the copyright and license terms
 ##
+from __future__ import absolute_import
 import re
 import os
 import yaml
@@ -13,7 +14,7 @@ import subprocess
 import sys
 
 from sibispy import sibislogger as slog
-from sibispy.svn import SibisSvnException, UpdateActionTypes
+from sibispy.svn_util import SibisSvnException, UpdateActionTypes
 import sibispy 
 
 import hashlib


### PR DESCRIPTION
This pull request depends upon:
- sibis-platform/sibispy#28
- sibis-platform/sibis-docker#25

This update updates to use the modified `sibispy.Session` that uses the new `sibispy.svn_util` module, which differs slightly from the previous implementation that utilized `pysvn` directly.

This is being done to support Python 2to3 migration where `pysvn` utilizes a native library that doesn't easily support python 2 and 3 simultaneously.

This was tested by running the tests tests in this project, as well as running the `front-nightly` script in the test environment.