### PR TITLE
fixed a problem with enumerating the return value from diff.files_changed.

### DIFF
--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -375,8 +375,8 @@ if dated_download :
     # Files that are added and deleted during the time period are now listed !
     try:
         diff = svn_client.diff_path(revision=dated_download)
-        for d in diff.files_changed(include_deleted=False):
-            updated_files.append(os.path.join(svndir,d.path))
+        for path in diff.files_changed(include_deleted=False):
+            updated_files.append(os.path.join(svndir,path))
 
     except SibisSvnException as ex:
         slog.info(hashlib.sha1('harvester' + str(ex)).hexdigest()[0:6],


### PR DESCRIPTION
Not sure why this didn't get caught earlier.

`SibisSvnDiff.files_changed(...)` returns a `list` of `str`, not a `list` of `SibisSvnDiffPath`.

Corrected so harvester now parses the right type.

Unfortunately there's currently no easy way to test this other than checking to see that it compiles, which it does.