### PR TITLE
Fix for #310

### DIFF
--- a/scripts/redcap/export_mr_sessions_spiral.py
+++ b/scripts/redcap/export_mr_sessions_spiral.py
@@ -35,7 +35,11 @@ def export_spiral_files(redcap_visit_id, xnat, redcap_key, resource_location, to
             tmpdir = tempfile.mkdtemp()
 
             try:
-                stroop_file_tmp = xnat.select.experiment(stroop[0]).resource(stroop[1]).file(stroop[2]).get_copy(os.path.join( tmpdir, stroop[2]))
+                stroop_file_path = os.path.join(tmpdir, stroop[2])
+                stroop_file_dir = os.path.dirname(stroop_file_path)
+                if not os.path.isdir(stroop_file_dir):
+                    os.makedirs(stroop_file_dir)
+                stroop_file_tmp = xnat.select.experiment(stroop[0]).resource(stroop[1]).file(stroop[2]).get_copy(stroop_file_dir)
             except IOError as e:
                 details = "Error: export_spiral_files: for experiment {0}, unable to get copy of resource {1} in file {2} to be saved here: {3}".format(str(stroop[0]), str(stroop[1]), str(stroop[2]), os.path.join( tmpdir, stroop[2]))
                 slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error={ 'message': str(e), 'details': details, 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })

--- a/scripts/redcap/export_mr_sessions_spiral.py
+++ b/scripts/redcap/export_mr_sessions_spiral.py
@@ -38,7 +38,7 @@ def export_spiral_files(redcap_visit_id, xnat, redcap_key, resource_location, to
                 stroop_file_tmp = xnat.select.experiment(stroop[0]).resource(stroop[1]).file(stroop[2]).get_copy(os.path.join( tmpdir, stroop[2]))
             except IOError as e:
                 details = "Error: export_spiral_files: for experiment {0}, unable to get copy of resource {1} in file {2} to be saved here: {3}".format(str(stroop[0]), str(stroop[1]), str(stroop[2]), os.path.join( tmpdir, stroop[2]))
-                slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error={ 'message': str(e), details: details, 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })
+                slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error={ 'message': str(e), 'details': details, 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })
                 return result
 
             from sanitize_eprime import copy_sanitize

--- a/scripts/redcap/import_mr_sessions_stroop.py
+++ b/scripts/redcap/import_mr_sessions_stroop.py
@@ -61,6 +61,10 @@ def import_stroop_to_redcap( xnat, stroop_eid, stroop_resource, stroop_file, \
 
     try:
         stroop_file_copy_path = os.path.join( tempdir, stroop_file )
+        stroop_dir_path = os.path.dirname(stroop_file_copy_path)
+        if not os.path.isdir(stroop_dir_path):
+            os.makedirs(stroop_dir_path)
+
         stroop_file_path = experiment.resource( stroop_resource ).file( stroop_file ).get_copy( stroop_file_copy_path )
     except IOError as e:
         details = "Error: import_mr_sessions_stroop: unable to get copy of resource {0} in file {1} to be saved here: {2}".format(stroop_resource, stroop_file, stroop_file_copy_path)

--- a/scripts/redcap/import_mr_sessions_stroop.py
+++ b/scripts/redcap/import_mr_sessions_stroop.py
@@ -64,7 +64,7 @@ def import_stroop_to_redcap( xnat, stroop_eid, stroop_resource, stroop_file, \
         stroop_file_path = experiment.resource( stroop_resource ).file( stroop_file ).get_copy( stroop_file_copy_path )
     except IOError as e:
         details = "Error: import_mr_sessions_stroop: unable to get copy of resource {0} in file {1} to be saved here: {2}".format(stroop_resource, stroop_file, stroop_file_copy_path)
-        slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error={ 'message': str(e), details: details, 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })
+        slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error={ 'message': str(e), 'details': details, 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })
         return
     # Convert downloaded Stroop file to CSV scores file
     cmd = str(os.path.join( import_bindir, "stroop2csv" )) +  ' --mr-session --record ' +  redcap_key[0] + ' --event ' + redcap_key[1] + " " + str(stroop_file_path) + ' ' + str(tempdir) 


### PR DESCRIPTION
Possibly something changed either in `pyxnat` or XNAT itself.

When copying a resource, it seems to no longer ensure that the destination directory exists when downloading.  This fixes the current errors we are getting that are causing the downloads to fail because of local sub path not getting created.