### PR TITLE
disable verbose downloads from xnat

### DIFF
--- a/scripts/redcap/export_mr_sessions_pipeline.py
+++ b/scripts/redcap/export_mr_sessions_pipeline.py
@@ -200,7 +200,7 @@ def copy_adni_phantom_t1w( xnat, xnat_eid, to_directory ):
 
     # Get first file from list, warn if more files
     (phantom_resource, phantom_file) = experiment_files[0]
-    experiment.resources[phantom_resource].files[ phantom_file ].download( phantom_path )
+    experiment.resources[phantom_resource].files[ phantom_file ].download( phantom_path, verbose=False )
 
     return True
 
@@ -230,7 +230,7 @@ def copy_adni_phantom_xml( xnat, xnat_eid, to_directory ):
 
     # Get first file from list, warn if more files
     (phantom_resource, phantom_file) = experiment_files[0]
-    experiment.resources[ phantom_resource ].files[ phantom_file ].download( phantom_path )
+    experiment.resources[ phantom_resource ].files[ phantom_file ].download( phantom_path, verbose=False )
 
     return True
 
@@ -298,7 +298,7 @@ def copy_rsfmri_physio_files( xnat, xnat_eid_and_scan, to_directory ):
             # fh is integer - if object is needed use tempfile.TemporaryFile()
             # fh.close()
 
-            experiment.resources[ physio_resource ].files[ physio_file ].download(physio_file_path_cache)
+            experiment.resources[ physio_resource ].files[ physio_file ].download(physio_file_path_cache, verbose=False)
 
             if not '.txt' in physio_file:
                 shutil.move( physio_file_path_cache, physio_file_path )

--- a/scripts/redcap/export_mr_sessions_spiral.py
+++ b/scripts/redcap/export_mr_sessions_spiral.py
@@ -41,7 +41,7 @@ def export_spiral_files(redcap_visit_id, xnat, redcap_key, resource_location, to
                 stroop_file_dir = os.path.dirname(stroop_file_path)
                 if not os.path.isdir(stroop_file_dir):
                     os.makedirs(stroop_file_dir)
-                xnat.select.experiments[stroop[0]].resources[stroop[1]].files[stroop[2]].download(stroop_file_path)
+                xnat.select.experiments[stroop[0]].resources[stroop[1]].files[stroop[2]].download(stroop_file_path, verbose=False)
             except IOError as e:
                 details = "Error: export_spiral_files: for experiment {0}, failed copying resource {1} file {2} to {3}".format(str(stroop[0]), str(stroop[1]), str(stroop[2]), os.path.join( tmpdir, stroop[2]))
                 slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error_obj={ 'message': str(e), 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })
@@ -69,7 +69,7 @@ def do_export_spiral_files(redcap_visit_id,xnat, redcap_key, resource_location, 
     [xnat_eid, resource_id, resource_file_bname] = resource_location.split('/')
     try : 
         tmp_file_path = os.path.join(tmpdir, "pfiles.tar.gz")
-        xnat.select.experiments[xnat_eid].resources[resource_id].files[resource_file_bname].download(tmp_file_path)
+        xnat.select.experiments[xnat_eid].resources[resource_id].files[resource_file_bname].download(tmp_file_path, verbose=False)
     except  Exception as err_msg:
         slog.info(xnat_eid + "_" +  resource_id, "Error: failed to download from xnat " + resource_file_bname, err_msg = str(err_msg))
         return False

--- a/scripts/redcap/import_mr_sessions_stroop.py
+++ b/scripts/redcap/import_mr_sessions_stroop.py
@@ -67,7 +67,7 @@ def import_stroop_to_redcap( xnat, stroop_eid, stroop_resource, stroop_file, \
         if not os.path.isdir(stroop_dir_path):
             os.makedirs(stroop_dir_path)
 
-        experiment.resources[stroop_resource].files[stroop_file].download( stroop_file_path )
+        experiment.resources[stroop_resource].files[stroop_file].download( stroop_file_path, verbose=False )
     except IOError as e:
         details = "Error: import_mr_sessions_stroop: unable to get copy resource {0} file {1} to {2}".format(stroop_resource, stroop_file, stroop_file_path)
         slog.info(str(redcap_key[0]) + "-" +  str(redcap_key[1]), details, error_obj={ 'message': str(e), 'errno': e.errno, 'filename': e.filename, 'strerror': e.strerror })


### PR DESCRIPTION
Disabled verbose downloads when using xnatpy api.  Verbose downloading is the default.

Tested on sibis and sibis-storage by passing `run_all_tests` in `sibispy`.