### PR TITLE
Load NA-like strings as-is. Closes #330.

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -503,7 +503,12 @@ for form_prefix, form_name in forms.items():
 
     forms = [form_name]
     return_format = 'df'
-    df_kwargs = {'index_col': import_project.def_field, 'dtype': 'object'}
+    df_kwargs = {'index_col': import_project.def_field,
+                 # Don't guess variable types
+                 'dtype': 'object',
+                 # Don't read in NA-like strings as np.nan
+                 'keep_default_na': False}
+
     returned_records = []
 
     for record_batch in batch(records, n=100):


### PR DESCRIPTION
Some fields in the Import project have NA-like string contents - e.g.
`n/a`. At some point, `pandas.read_csv` began to read those values as
`numpy.nan` by default. But that was likely after pandas 0.14, which the
pipeline used until recently.

This means that for a good amount of locked and finished Entry records,
NA-like literals were initially transferred as literals - but are not
anymore. See e.g. sibis-platform/ncanda-operations#7846 and other
40-some errors that came up during the last `update_visit_data -a`.

`df_kwargs` is passed to `pandas.read_csv(**df_kwargs)`
via `redcap.Project.export_records`. `keep_default_na=False` ensures
that only empty strings are read in as `numpy.nan`.