### PR TITLE
Add a configurable destination filter to harvester

### DIFF
--- a/scripts/import/laptops/config_utils.py
+++ b/scripts/import/laptops/config_utils.py
@@ -45,16 +45,3 @@ def flatten_path_dict(path_dict, base_prefix="", delimiter=os.sep):
         elif isinstance(val, string_types):
             output.append(new_prefix + delimiter + val)
     return output
-
-# if __name__ == '__main__':
-#     paths = {'ohsu': 
-#                 {'test': 'simple', 
-#                  'pasat': [
-#                      'A-31', 
-#                      'B-32', 
-#                      {'example': ['C-20']}]}}
-#         ['/fs/storage/laptops/import/ohsu/test/simple',
-#          '/fs/storage/laptops/import/ohsu/pasat/A-31',
-#          '/fs/storage/laptops/import/ohsu/pasat/B-32',
-#          '/fs/storage/laptops/import/ohsu/pasat/example/C-20']
-#     print(flatten_path_dict(paths, '/fs/storage/laptops/import'))

--- a/scripts/import/laptops/config_utils.py
+++ b/scripts/import/laptops/config_utils.py
@@ -1,0 +1,60 @@
+from itertools import chain
+import os
+from six import string_types
+
+
+def flatten_path_dict(path_dict, base_prefix="", delimiter=os.sep):
+    """
+    Convert a directory tree dict into a list of leaf file paths.
+
+    For example:
+
+    paths = {'ohsu':
+                {'test': 'simple',
+                 'pasat': [
+                     'A-31',
+                     'B-32',
+                     {'example': ['C-20']}
+                 ]}}
+
+    flatten_path_dict(paths, base_prefix='/fs/storage/laptops/import')
+
+    # => ['/fs/storage/laptops/import/ohsu/test/simple',
+    #     '/fs/storage/laptops/import/ohsu/pasat/A-31',
+    #     '/fs/storage/laptops/import/ohsu/pasat/B-32',
+    #     '/fs/storage/laptops/import/ohsu/pasat/example/C-20']
+    """
+    # NOTE: On reflection, this is not well-recursed; working towards a string
+    # base case would have been more elegant and possibly more robust.
+    output = []
+    for key, val in path_dict.items():
+        new_prefix = base_prefix + delimiter + key
+        if isinstance(val, dict):
+            # The value is a subdirectory -> recurse
+            output.extend(flatten_path_dict(val, new_prefix, delimiter))
+        elif isinstance(val, list):
+            # List will contain either strings ready for concatenation...
+            output.extend(
+                    [new_prefix + delimiter + item
+                        for item in val if not isinstance(item, dict)])
+            # ...or more dict subdirs to recurse into
+            output.extend(  # chain.from_iterable flattens the resulting list
+                    chain.from_iterable(
+                        [flatten_path_dict(item, new_prefix, delimiter)
+                            for item in val if isinstance(item, dict)]))
+        elif isinstance(val, string_types):
+            output.append(new_prefix + delimiter + val)
+    return output
+
+# if __name__ == '__main__':
+#     paths = {'ohsu': 
+#                 {'test': 'simple', 
+#                  'pasat': [
+#                      'A-31', 
+#                      'B-32', 
+#                      {'example': ['C-20']}]}}
+#         ['/fs/storage/laptops/import/ohsu/test/simple',
+#          '/fs/storage/laptops/import/ohsu/pasat/A-31',
+#          '/fs/storage/laptops/import/ohsu/pasat/B-32',
+#          '/fs/storage/laptops/import/ohsu/pasat/example/C-20']
+#     print(flatten_path_dict(paths, '/fs/storage/laptops/import'))

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -18,6 +18,8 @@ from sibispy import sibislogger as slog
 from sibispy.svn_util import SibisSvnException, UpdateActionTypes
 import sibispy 
 
+from config_utils import flatten_path_dict
+
 import hashlib
 updated_files = []
 
@@ -139,11 +141,19 @@ if harvster_setting:
                   " %s; should be YYYY-MM-DD.").format(laptop,
                                                        infer_dag_since[laptop]))
             infer_dag_since[laptop] = None
+
+    # Load destination paths that are verboten
+    ignore_processed_tree = harvster_setting.get('ignore_processed_paths', {})
+    # Make tree into a list of paths
+    ignore_processed = flatten_path_dict(ignore_processed_tree, outdir)
+    # Normalize the paths so that string comparison can be used
+    ignore_processed = [os.path.normpath(item) for item in ignore_processed]
 else:
     # FIXME: Should condition on args.verbose?
     print("Warning: harvester specific settings not defined!")
     ignore_data = dict()
     infer_dag_since = dict()
+    ignore_processed = []
 
 def run_converter(site, subject_label, command, verbose, infer_dag=False):
     """
@@ -178,7 +188,10 @@ def run_converter(site, subject_label, command, verbose, infer_dag=False):
                               file=str(fi),
                               converter_cmd=" ".join(command), 
                               harvester_cmd=" ".join(sys.argv)) 
-                else : 
+                elif os.path.normpath(fi) in ignore_processed:
+                    if verbose:
+                        print("Destination {} is ignored per configuration.".format(fi))
+                else:
                     try:
                         if verbose:
                             print("Importing", fi, "into REDCap")


### PR DESCRIPTION
Given a YAML-specified directory tree, harvester will get a list of paths to ignore during processing. (This is useful for e.g. sibis-platform/ncanda-operations/issues/7687 - cases where the converter is not aware of laptop of origin.)

For example, the following specification...

```yaml
harvester:
  ignore_processed_paths:
    ohsu:
      pasat: &DUPLICATED_PASAT_FILES
        - E-01099-M-7-2017-09-19.csv
        - E-01318-M-2-2017-08-28.csv
    sri:
      pasat: *DUPLICATED_PASAT_FILES
```

...will block the following paths:

- /fs/storage/laptops/imported/ohsu/pasat/E-01099-M-7-2017-09-19.csv
- /fs/storage/laptops/imported/ohsu/pasat/E-01318-M-2-2017-08-28.csv
- /fs/storage/laptops/imported/sri/pasat/E-01099-M-7-2017-09-19.csv
- /fs/storage/laptops/imported/sri/pasat/E-01318-M-2-2017-08-28.csv