### PR TITLE
Revert "Load NA-like strings as-is. Closes #330."

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -503,12 +503,7 @@ for form_prefix, form_name in forms.items():
 
     forms = [form_name]
     return_format = 'df'
-    df_kwargs = {'index_col': import_project.def_field,
-                 # Don't guess variable types
-                 'dtype': 'object',
-                 # Don't read in NA-like strings as np.nan
-                 'keep_default_na': False}
-
+    df_kwargs = {'index_col': import_project.def_field, 'dtype': 'object'}
     returned_records = []
 
     for record_batch in batch(records, n=100):


### PR DESCRIPTION
This reverts commit 472c122868023432cb6325cd352ae7da0b138f7e.

In short, we actually *do* want pandas to read NA-like strings as NAs.
We'll unlock the Entry records we need to unlock to overwrite the
current NA literals with blanks.

See discussion in
https://github.com/sibis-platform/ncanda-operations/issues/7895#issuecomment-531462914
for details.