### PR TITLE
Ignore backup/swap/duplicate/debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ target/
 
 # IPython / Jupyter Notebooks
 .ipynb_checkpoints
+
+# Leftovers and backups
+*~
+*_
+scripts/import/webcnp/debug_script


### PR DESCRIPTION
Whenever edited for a hotfix, the production repo ends up containing flotsam files - vim/emacs backup/swap files, single-use debug files, etc:

```
# sibis@ncanda: /sibis-software/ncanda-data-integration (master)
$ git status

On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        scripts/crond/valid_container_back-nightly.log~
        scripts/crond/valid_container_front-hourly.log~
        scripts/import/webcnp/debug_script
        scripts/import/webcnp/update_summary_forms_
        scripts/import/webcnp/update_summary_forms_~
        scripts/xnat/upload_visual_qc.py_
```

This PR adds the most common offenders into `.gitignore`.