### PR TITLE
Create issue if stroop2csv ID conversion changes a valid site ID

### DIFF
--- a/scripts/import/laptops/convert_util.py
+++ b/scripts/import/laptops/convert_util.py
@@ -3,7 +3,7 @@ import hashlib
 from sibispy import sibislogger as slog
 
 # have to post issues that way so that github is not overwhelmed with calls 
-def post_issue_and_exit(script, infile, verbose, post_to_github, issue_label, issue_title, **kwargs) : 
+def post_issue(script, infile, verbose, post_to_github, issue_label, issue_title, **kwargs):
     slog.init_log(verbose, post_to_github,'NCANDA Import-Laptop: ' + script + ' Message', script)
 
     if 'post_resolution_instructions' not in kwargs:
@@ -13,6 +13,10 @@ def post_issue_and_exit(script, infile, verbose, post_to_github, issue_label, is
         del kwargs['post_resolution_instructions']
     
     slog.info(issue_label + "-" + hashlib.sha1(infile.encode()).hexdigest()[0:6], issue_title, cmd = " ".join(sys.argv), post_resolution_instructions = infoTxt, **kwargs) 
-  
-    sys.exit(1)
 
+
+def post_issue_and_exit(script, infile, verbose, post_to_github, issue_label,
+                        issue_title, **kwargs):
+    post_issue(script, infile, verbose, post_to_github, issue_label,
+               issue_title, **kwargs)
+    sys.exit(1)

--- a/scripts/import/laptops/stroop2csv
+++ b/scripts/import/laptops/stroop2csv
@@ -17,11 +17,14 @@ import math
 import argparse
 import hashlib
 import numpy as np
+from pathlib import Path
+
+from convert_util import post_issue
+
 
 def post_issue_and_exit(issue_label, issue_title, **kwargs):
     import convert_util
     convert_util.post_issue_and_exit('stroop2csv', args.infile, args.verbose, args.post_to_github, issue_label, issue_title, **kwargs)
-
 
 # Setup command line parser
 parser = argparse.ArgumentParser( description="Convert e-Prime Stroop log file to CSV score file" )
@@ -103,6 +106,25 @@ if os.path.exists(output_filename):
             errMsg = 0
 
         sys.exit(errMsg)
+
+# Check that the extracted ID hasn't changed from sites
+_upload_path = Path(args.infile).parent.name
+_upload_id = _upload_path[0:11]
+_upload_site = _upload_path[0]
+if subject_id[0] != _upload_site and (_upload_site in 'ABCDE'):
+    post_issue(script='stroop2csv',
+               infile=args.infile,
+               verbose=args.verbose,
+               post_to_github=args.post_to_github,
+               issue_label="StroopIDChange",
+               issue_title="Warning: stroop2csv file changed sites",
+               to_resolve="Instruct the site to review the Import record "
+                          "and, if appropriate, correct the subject ID.",
+               post_resolution_instructions="Close after notifying site.",
+               reopened="If this issue has reopened, the file is being "
+               "reprocessed. Add it to special_cases.yml::harvester::ignore.",
+               old_id=_upload_id,
+               new_id=subject_id)
 
 # convert response time to integer
 RT=[float(x) for x in RT]


### PR DESCRIPTION
Reusing the machinery from `convert_utils` (mildly refactored to avoid exiting, since this is just a warning). Checked with a valid file (doesn't raise) and a known problematic file (does raise).

Issues (probably not solvable without touching sibispy / harvester):

- If called from `harvester` without `-p`, the line is printed to stdout and `harvester` is confused that it's not a file. Verbosity doesn't seem to matter.
- There's no ignore except `harvester` ignore. (Which should be fine.)