### PR TITLE
Add optional CLI progress bar to long-running scripts

### DIFF
--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -13,7 +13,7 @@ import argparse
 import subprocess
 
 import sys
-import tqdm
+from tqdm import tqdm
 
 from sibispy import sibislogger as slog
 from sibispy.svn_util import SibisSvnException, UpdateActionTypes
@@ -419,12 +419,9 @@ if args.verbose :
  
 # Append single file to upload
 
-if args.progress_bar:
-    updated_file_iterator = tqdm.tqdm(updated_files, unit="files")
-else:
-    updated_file_iterator = updated_files
 # Process all updated or added files
-for file in updated_file_iterator:
+# Equivalent to for file in updated_files, but with optional progress bar
+for file in tqdm(updated_files, unit="files", disable=not args.progress_bar):
     # Test if excemption is set 
     if file.startswith(svndir):
         check_file = file[len(svndir):]

--- a/scripts/import/laptops/harvester
+++ b/scripts/import/laptops/harvester
@@ -13,6 +13,7 @@ import argparse
 import subprocess
 
 import sys
+import tqdm
 
 from sibispy import sibislogger as slog
 from sibispy.svn_util import SibisSvnException, UpdateActionTypes
@@ -93,6 +94,8 @@ parser.add_argument("--omit-svn-update",
                     help="Do not run svn update. It is set to true when script is called with --file-to-upload. Only explicitly set flag when debugging an issue",
                     action="store_true",
                     default=False)
+
+parser.add_argument('--progress-bar', help="Show TQDM progress bar", action="store_true")
 
 # NOTE: Although most of the harvester logic is abstracted into functions, note
 #       that most functions rely on the `args` variable to be available from
@@ -416,8 +419,12 @@ if args.verbose :
  
 # Append single file to upload
 
+if args.progress_bar:
+    updated_file_iterator = tqdm.tqdm(updated_files, unit="files")
+else:
+    updated_file_iterator = updated_files
 # Process all updated or added files
-for file in updated_files:
+for file in updated_file_iterator:
     # Test if excemption is set 
     if file.startswith(svndir):
         check_file = file[len(svndir):]

--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -22,7 +22,7 @@ import pandas
 import redcap
 import requests
 import hashlib 
-import tqdm
+from tqdm import tqdm
 
 import sibispy
 from sibispy import sibislogger as slog
@@ -569,16 +569,11 @@ for form_prefix, form_name in forms.items():
         entry_form_data = entry_form_data[ ~(entry_form_data[complete_label] > 1)]
 
     # Go over all summary records (i.e., the visit log) from entry project and find corresponding imported records
-    # Prepare an optional TQDM progress bar
-    if args.progress_bar:
-        record_iterator = tqdm.tqdm(entry_form_data.iterrows(),
-                                    total=entry_form_data.shape[0],
-                                    desc=form_prefix)
-    else:
-        record_iterator = entry_form_data.iterrows()
-
     index = 0
-    for key, row in record_iterator:
+    for key, row in tqdm(entry_form_data.iterrows(),      # the actual iterator
+                         total=entry_form_data.shape[0],  # progress bar meta
+                         desc=form_prefix,
+                         disable=not args.progress_bar):
         if args.verbose :
             print("Processing", key)
         # Select imported records for this subject

--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -22,6 +22,7 @@ import pandas
 import redcap
 import requests
 import hashlib 
+import tqdm
 
 import sibispy
 from sibispy import sibislogger as slog
@@ -331,6 +332,8 @@ parser.add_argument("-t","--time-log-dir",
                     action="store",
                     default=None)
 
+parser.add_argument('--progress-bar', help="Show TQDM progress bar", action="store_true")
+
 args = parser.parse_args()
 
 
@@ -566,8 +569,16 @@ for form_prefix, form_name in forms.items():
         entry_form_data = entry_form_data[ ~(entry_form_data[complete_label] > 1)]
 
     # Go over all summary records (i.e., the visit log) from entry project and find corresponding imported records
+    # Prepare an optional TQDM progress bar
+    if args.progress_bar:
+        record_iterator = tqdm.tqdm(entry_form_data.iterrows(),
+                                    total=entry_form_data.shape[0],
+                                    desc=form_prefix)
+    else:
+        record_iterator = entry_form_data.iterrows()
+
     index = 0
-    for key, row in entry_form_data.iterrows():
+    for key, row in record_iterator:
         if args.verbose :
             print("Processing", key)
         # Select imported records for this subject

--- a/scripts/redcap/export_measures
+++ b/scripts/redcap/export_measures
@@ -18,7 +18,7 @@ import hashlib
 
 import yaml
 import pandas
-import tqdm
+from tqdm import tqdm
 
 import sibispy
 from sibispy import sibislogger as slog
@@ -281,14 +281,10 @@ if args.verbose:
     print("Exporting %d REDCap records." % len( visit_log_redcap ))
 
 # Iterate over all remaining rows
-if args.progress_bar:
-    record_iterator = tqdm.tqdm(visit_log_redcap.iterrows(),
-                                total=visit_log_redcap.shape[0],
-                                unit="subjects")
-else:
-    record_iterator = visit_log_redcap.iterrows()
-
-for [key, row] in record_iterator:
+for [key, row] in tqdm(visit_log_redcap.iterrows(),  # the actual iterator
+                       total=visit_log_redcap.shape[0],
+                       unit="subjects",
+                       disable=not args.progress_bar):
     # map the redcap subject key to readable vars
     redcap_subject, redcap_event = key
     

--- a/scripts/redcap/export_measures
+++ b/scripts/redcap/export_measures
@@ -18,6 +18,7 @@ import hashlib
 
 import yaml
 import pandas
+import tqdm
 
 import sibispy
 from sibispy import sibislogger as slog
@@ -71,6 +72,7 @@ parser.add_argument("-t", "--time-log-dir",
                     help="If set then time logs are written to that directory",
                     action="store",
                     default=None)
+parser.add_argument('--progress-bar', help="Show TQDM progress bar", action="store_true")
 args = parser.parse_args()
 
 slog.init_log(args.verbose, args.post_to_github, 'NCANDA ', 'export_measures',
@@ -279,7 +281,14 @@ if args.verbose:
     print("Exporting %d REDCap records." % len( visit_log_redcap ))
 
 # Iterate over all remaining rows
-for [key,row] in visit_log_redcap.iterrows():
+if args.progress_bar:
+    record_iterator = tqdm.tqdm(visit_log_redcap.iterrows(),
+                                total=visit_log_redcap.shape[0],
+                                unit="subjects")
+else:
+    record_iterator = visit_log_redcap.iterrows()
+
+for [key, row] in record_iterator:
     # map the redcap subject key to readable vars
     redcap_subject, redcap_event = key
     


### PR DESCRIPTION
This uses tqdm, which we already have in the container. It's an
alternative to `verbose` mode, which is typically substantially *more*
verbose and doesn't really establish how much work is left.

It works by wrapping an iterator, and is fully optional.