### PR TITLE
Bugfix: Process scans that have *no* value for PhantomMissingOverride

### DIFF
--- a/scripts/xnat/check_phantom_scans
+++ b/scripts/xnat/check_phantom_scans
@@ -282,7 +282,7 @@ for eid in experiment_ids:
         continue
 
     # Do not change to True ! as xnat saves it as 'true' 
-    if 'phantommissingoverride' in experiment.fields and experiment.fields['phantommissingoverride'] != 'true':
+    if experiment.fields.get('phantommissingoverride') != 'true':
         count_phantom += 1
         check_experiment(session, eid, experiment)
 


### PR DESCRIPTION
Since scans have no PhantomMissingOverride value by default, this omitted many scans from `check_phantom_scans`.

The trouble is that this will likely require a `sibispy` change as well, because this ends up throwing three errors per one changed-site (I think) MR session. **Something is wrong with the lookup of phantom info for those scans.** Quoting from #370:

> `session.xnat_get_subject_attribute(prj,phantom_label,'ID')` (around L139) throws two separate SIBIS errors for (I think) changed-site cases and this script then throws a third:
>
> ```
> {"experiment_site_id": "B-99999-P-9-46643e", "error": "ERROR: subject could not be found!", "err_msg": "'Could not find ID/label B-99999-P-9 in collection!'", "project": "ucsd_incoming", "function": "session.xnat_get_subject", "subject": "B-99999-P-9"}
> {"experiment_site_id": "B-99999-P-9", "error": "ERROR: session.xnat_get_subject_attribute: subject B-99999-P-9 not found !", "project": "ucsd_incoming"}
> {"experiment_site_id": "NCANDA_E08899", "error": "Could not get phantom id for phantom B-99999-P-9", "project_id": "ucsd_incoming", "phantom": "B-99999-P-9", "related_issues": [], "cmd": "xnat/check_phantom_scans -a"}
> ```
>
> The good news is that when I ran `check_phantom_scans -a` with the patched version, these were the only errors that came up, meaning that the scans without `phantommissingoverride` always did have a phantom close by, even though we hadn't checked them.
