### PR TITLE
Update CNP retrieval to work with the new WebCNP survey

### DIFF
--- a/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
+++ b/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
@@ -1216,18 +1216,18 @@ SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,NumLet CPT Final Run of No
 SVOLTD_A_ScorVers,SVOLTD_A_ScorVers,SVOLTD,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_status,SVOLTD_A_status,SVDELAY_status,Status Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_valid_code,SVOLTD_A_valid_code,SVDELAY_valid_code,Valid Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LD,SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVTLDRTC,SVOLTD_A_SVTLDRTC,SVDELAY_SVTLDRTC,Median Response Time for SVOLTD Correct Responses (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVTLDRTER,SVOLTD_A_SVTLDRTER,SVDELAY_SVTLDRTER,Median Response Time for SVOLTD Incorrect Responses (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTP,SVOLTD_A_SVT_LDTP,SVDELAY_SVT_LDTP,SVOLTD True Positive Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTN,SVOLTD_A_SVT_LDTN,SVDELAY_SVT_LDTN,SVOLTD True Negative Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFP,SVOLTD_A_SVT_LDFP,SVDELAY_SVT_LDFP,SVOLTD False Positive Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFN,SVOLTD_A_SVT_LDFN,SVDELAY_SVT_LDFN,SVOLTD False Negative Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTPRT,SVOLTD_A_SVT_LDTPRT,SVDELAY_SVT_LDTPRT,SVOLTD True Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTNRT,SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFPRT,SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFNRT,SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_EFFD,SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_CR,SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_RTCR,SVOLTD_A_SVTLDRTC,SVDELAY_SVTLDRTC,Median Response Time for SVOLTD Correct Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_RTER,SVOLTD_A_SVTLDRTER,SVDELAY_SVTLDRTER,Median Response Time for SVOLTD Incorrect Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_TP,SVOLTD_A_SVT_LDTP,SVDELAY_SVT_LDTP,SVOLTD True Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_TN,SVOLTD_A_SVT_LDTN,SVDELAY_SVT_LDTN,SVOLTD True Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_FP,SVOLTD_A_SVT_LDFP,SVDELAY_SVT_LDFP,SVOLTD False Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_FN,SVOLTD_A_SVT_LDFN,SVDELAY_SVT_LDFN,SVOLTD False Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_TPRT,SVOLTD_A_SVT_LDTPRT,SVDELAY_SVT_LDTPRT,SVOLTD True Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_TNRT,SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_FPRT,SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_FNRT,SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVOLTD_EFF,SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
 SFNB2_ScorVers,SFNB2_ScorVers,SFNB2,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
 SFNB2_status,SFNB2_status,SFNB2_status,SFNB2 completion status,Short Fractal-N-Back- 2 Back Version
 SFNB2_valid_code,SFNB2_valid_code,SFNB2_valid_code,SFNB2 valid code,Short Fractal-N-Back- 2 Back Version

--- a/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
+++ b/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
@@ -1,1160 +1,1370 @@
-survey_var,evioni_var,description,test
-test_sessions_datasetid,test_sessions_datasetid,Unique Number for that CNB,Test Sessions
-test_sessions_siteid,test_sessions_siteid,Site ID battery was administered to,Test Sessions
-test_sessions_famid,test_sessions_famid,Family ID battery was administered to,Test Sessions
-test_sessions_subid,test_sessions_subid,Subject ID battery was administered to,Test Sessions
-test_sessions_v_bblid,test_sessions_bblid,BBLID battery was administered to,Test Sessions
-test_sessions_v_battery,test_sessions_battery,Battery Name,Test Sessions
-test_sessions_v_age,test_sessions_age,Age of participant,Test Sessions
-test_sessions_v_gender,test_sessions_gender,Gender of participant,Test Sessions
-test_sessions_v_dotest,test_sessions_dotest,Date of CNB,Test Sessions
-test_sessions_v_dob,test_sessions_dob,Date of Birth of participant,Test Sessions
-test_sessions_v_handedness,test_sessions_handedness,Handedness of participant,Test Sessions
-test_sessions_v_education,test_sessions_education,Highest Level of Education of participant,Test Sessions
-test_sessions_v_feducation,test_sessions_feducation,Highest Level of Education of participant's father,Test Sessions
-test_sessions_v_meducation,test_sessions_meducation,Highest Level of Education of participant's mother,Test Sessions
-test_sessions_v_admin_comments,test_sessions_admin_comments,Administrator Comments,Test Sessions
-test_sessions_v_valid_code,test_sessions_valid_code,Validation Code Assigned,Test Sessions
-CPF_A_ScorVers,CPF,Current Programming Version of the Scoring Code,Penn Facial Memory Test
-CPF_A_status,CPF_status,Status Code Assigned to CPF,Penn Facial Memory Test
-CPF_A_valid_code,CPF_valid_code,Valid Code Assigned to CPF,Penn Facial Memory Test
-CPF_A_CPF_TP,CPF_CPFTP,CPF True Positives,Penn Facial Memory Test
-CPF_A_CPF_TN,CPF_CPFTN,CPF True Negatives,Penn Facial Memory Test
-CPF_A_CPF_FP,CPF_CPFFP,CPF False Positives,Penn Facial Memory Test
-CPF_A_CPF_FN,CPF_CPFFN,CPF False Negatives,Penn Facial Memory Test
-CPF_A_CPF_TPRT,CPF_CPFTPRT,CPF True Positives Median Response Time (ms),Penn Facial Memory Test
-CPF_A_CPF_TNRT,CPF_CPFTNRT,CPF True Negatives Median Response Time (ms),Penn Facial Memory Test
-CPF_A_CPF_FPRT,CPF_CPFFPRT,CPF False Positives Median Response Time (ms),Penn Facial Memory Test
-CPF_A_CPF_FNRT,CPF_CPFFNRT,CPF False Negatives Median Response Time (ms),Penn Facial Memory Test
-CPF_IFAC_TOT,CPF_IFAC_TOT,CPF Total Correct Responses,Penn Facial Memory Test
-CPF_IFAC_RTC,CPF_IFAC_RTC,CPF Median Total Correct Response Time (ms),Penn Facial Memory Test
-CPF_A_CPF_trial000001_resp,CPF_q1_resp,Response for trial 1,Penn Facial Memory Test
-CPF_A_CPF_trial000001_ttr,CPF_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test
-CPF_A_CPF_trial000001_corr,CPF_q1_corr,Response correct for trial 1,Penn Facial Memory Test
-CPF_A_CPF_trial000002_resp,CPF_q2_resp,Response for trial 2,Penn Facial Memory Test
-CPF_A_CPF_trial000002_ttr,CPF_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test
-CPF_A_CPF_trial000002_corr,CPF_q2_corr,Response correct for trial 2,Penn Facial Memory Test
-CPF_A_CPF_trial000003_resp,CPF_q3_resp,Response for trial 3,Penn Facial Memory Test
-CPF_A_CPF_trial000003_ttr,CPF_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test
-CPF_A_CPF_trial000003_corr,CPF_q3_corr,Response correct for trial 3,Penn Facial Memory Test
-CPF_A_CPF_trial000004_resp,CPF_q4_resp,Response for trial 4,Penn Facial Memory Test
-CPF_A_CPF_trial000004_ttr,CPF_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test
-CPF_A_CPF_trial000004_corr,CPF_q4_corr,Response correct for trial 4,Penn Facial Memory Test
-CPF_A_CPF_trial000005_resp,CPF_q5_resp,Response for trial 5,Penn Facial Memory Test
-CPF_A_CPF_trial000005_ttr,CPF_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test
-CPF_A_CPF_trial000005_corr,CPF_q5_corr,Response correct for trial 5,Penn Facial Memory Test
-CPF_A_CPF_trial000006_resp,CPF_q6_resp,Response for trial 6,Penn Facial Memory Test
-CPF_A_CPF_trial000006_ttr,CPF_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test
-CPF_A_CPF_trial000006_corr,CPF_q6_corr,Response correct for trial 6,Penn Facial Memory Test
-CPF_A_CPF_trial000007_resp,CPF_q7_resp,Response for trial 7,Penn Facial Memory Test
-CPF_A_CPF_trial000007_ttr,CPF_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test
-CPF_A_CPF_trial000007_corr,CPF_q7_corr,Response correct for trial 7,Penn Facial Memory Test
-CPF_A_CPF_trial000008_resp,CPF_q8_resp,Response for trial 8,Penn Facial Memory Test
-CPF_A_CPF_trial000008_ttr,CPF_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test
-CPF_A_CPF_trial000008_corr,CPF_q8_corr,Response correct for trial 8,Penn Facial Memory Test
-CPF_A_CPF_trial000009_resp,CPF_q9_resp,Response for trial 9,Penn Facial Memory Test
-CPF_A_CPF_trial000009_ttr,CPF_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test
-CPF_A_CPF_trial000009_corr,CPF_q9_corr,Response correct for trial 9,Penn Facial Memory Test
-CPF_A_CPF_trial000010_resp,CPF_q10_resp,Response for trial 10,Penn Facial Memory Test
-CPF_A_CPF_trial000010_ttr,CPF_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test
-CPF_A_CPF_trial000010_corr,CPF_q10_corr,Response correct for trial 10,Penn Facial Memory Test
-CPF_A_CPF_trial000011_resp,CPF_q11_resp,Response for trial 11,Penn Facial Memory Test
-CPF_A_CPF_trial000011_ttr,CPF_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test
-CPF_A_CPF_trial000011_corr,CPF_q11_corr,Response correct for trial 11,Penn Facial Memory Test
-CPF_A_CPF_trial000012_resp,CPF_q12_resp,Response for trial 12,Penn Facial Memory Test
-CPF_A_CPF_trial000012_ttr,CPF_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test
-CPF_A_CPF_trial000012_corr,CPF_q12_corr,Response correct for trial 12,Penn Facial Memory Test
-CPF_A_CPF_trial000013_resp,CPF_q13_resp,Response for trial 13,Penn Facial Memory Test
-CPF_A_CPF_trial000013_ttr,CPF_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test
-CPF_A_CPF_trial000013_corr,CPF_q13_corr,Response correct for trial 13,Penn Facial Memory Test
-CPF_A_CPF_trial000014_resp,CPF_q14_resp,Response for trial 14,Penn Facial Memory Test
-CPF_A_CPF_trial000014_ttr,CPF_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test
-CPF_A_CPF_trial000014_corr,CPF_q14_corr,Response correct for trial 14,Penn Facial Memory Test
-CPF_A_CPF_trial000015_resp,CPF_q15_resp,Response for trial 15,Penn Facial Memory Test
-CPF_A_CPF_trial000015_ttr,CPF_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test
-CPF_A_CPF_trial000015_corr,CPF_q15_corr,Response correct for trial 15,Penn Facial Memory Test
-CPF_A_CPF_trial000016_resp,CPF_q16_resp,Response for trial 16,Penn Facial Memory Test
-CPF_A_CPF_trial000016_ttr,CPF_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test
-CPF_A_CPF_trial000016_corr,CPF_q16_corr,Response correct for trial 16,Penn Facial Memory Test
-CPF_A_CPF_trial000017_resp,CPF_q17_resp,Response for trial 17,Penn Facial Memory Test
-CPF_A_CPF_trial000017_ttr,CPF_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test
-CPF_A_CPF_trial000017_corr,CPF_q17_corr,Response correct for trial 17,Penn Facial Memory Test
-CPF_A_CPF_trial000018_resp,CPF_q18_resp,Response for trial 18,Penn Facial Memory Test
-CPF_A_CPF_trial000018_ttr,CPF_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test
-CPF_A_CPF_trial000018_corr,CPF_q18_corr,Response correct for trial 18,Penn Facial Memory Test
-CPF_A_CPF_trial000019_resp,CPF_q19_resp,Response for trial 19,Penn Facial Memory Test
-CPF_A_CPF_trial000019_ttr,CPF_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test
-CPF_A_CPF_trial000019_corr,CPF_q19_corr,Response correct for trial 19,Penn Facial Memory Test
-CPF_A_CPF_trial000020_resp,CPF_q20_resp,Response for trial 20,Penn Facial Memory Test
-CPF_A_CPF_trial000020_ttr,CPF_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test
-CPF_A_CPF_trial000020_corr,CPF_q20_corr,Response correct for trial 20,Penn Facial Memory Test
-CPF_A_CPF_trial000021_resp,CPF_q21_resp,Response for trial 21,Penn Facial Memory Test
-CPF_A_CPF_trial000021_ttr,CPF_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test
-CPF_A_CPF_trial000021_corr,CPF_q21_corr,Response correct for trial 21,Penn Facial Memory Test
-CPF_A_CPF_trial000022_resp,CPF_q22_resp,Response for trial 22,Penn Facial Memory Test
-CPF_A_CPF_trial000022_ttr,CPF_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test
-CPF_A_CPF_trial000022_corr,CPF_q22_corr,Response correct for trial 22,Penn Facial Memory Test
-CPF_A_CPF_trial000023_resp,CPF_q23_resp,Response for trial 23,Penn Facial Memory Test
-CPF_A_CPF_trial000023_ttr,CPF_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test
-CPF_A_CPF_trial000023_corr,CPF_q23_corr,Response correct for trial 23,Penn Facial Memory Test
-CPF_A_CPF_trial000024_resp,CPF_q24_resp,Response for trial 24,Penn Facial Memory Test
-CPF_A_CPF_trial000024_ttr,CPF_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test
-CPF_A_CPF_trial000024_corr,CPF_q24_corr,Response correct for trial 24,Penn Facial Memory Test
-CPF_A_CPF_trial000025_resp,CPF_q25_resp,Response for trial 25,Penn Facial Memory Test
-CPF_A_CPF_trial000025_ttr,CPF_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test
-CPF_A_CPF_trial000025_corr,CPF_q25_corr,Response correct for trial 25,Penn Facial Memory Test
-CPF_A_CPF_trial000026_resp,CPF_q26_resp,Response for trial 26,Penn Facial Memory Test
-CPF_A_CPF_trial000026_ttr,CPF_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test
-CPF_A_CPF_trial000026_corr,CPF_q26_corr,Response correct for trial 26,Penn Facial Memory Test
-CPF_A_CPF_trial000027_resp,CPF_q27_resp,Response for trial 27,Penn Facial Memory Test
-CPF_A_CPF_trial000027_ttr,CPF_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test
-CPF_A_CPF_trial000027_corr,CPF_q27_corr,Response correct for trial 27,Penn Facial Memory Test
-CPF_A_CPF_trial000028_resp,CPF_q28_resp,Response for trial 28,Penn Facial Memory Test
-CPF_A_CPF_trial000028_ttr,CPF_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test
-CPF_A_CPF_trial000028_corr,CPF_q28_corr,Response correct for trial 28,Penn Facial Memory Test
-CPF_A_CPF_trial000029_resp,CPF_q29_resp,Response for trial 29,Penn Facial Memory Test
-CPF_A_CPF_trial000029_ttr,CPF_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test
-CPF_A_CPF_trial000029_corr,CPF_q29_corr,Response correct for trial 29,Penn Facial Memory Test
-CPF_A_CPF_trial000030_resp,CPF_q30_resp,Response for trial 30,Penn Facial Memory Test
-CPF_A_CPF_trial000030_ttr,CPF_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test
-CPF_A_CPF_trial000030_corr,CPF_q30_corr,Response correct for trial 30,Penn Facial Memory Test
-CPF_A_CPF_trial000031_resp,CPF_q31_resp,Response for trial 31,Penn Facial Memory Test
-CPF_A_CPF_trial000031_ttr,CPF_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test
-CPF_A_CPF_trial000031_corr,CPF_q31_corr,Response correct for trial 31,Penn Facial Memory Test
-CPF_A_CPF_trial000032_resp,CPF_q32_resp,Response for trial 32,Penn Facial Memory Test
-CPF_A_CPF_trial000032_ttr,CPF_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test
-CPF_A_CPF_trial000032_corr,CPF_q32_corr,Response correct for trial 32,Penn Facial Memory Test
-CPF_A_CPF_trial000033_resp,CPF_q33_resp,Response for trial 33,Penn Facial Memory Test
-CPF_A_CPF_trial000033_ttr,CPF_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test
-CPF_A_CPF_trial000033_corr,CPF_q33_corr,Response correct for trial 33,Penn Facial Memory Test
-CPF_A_CPF_trial000034_resp,CPF_q34_resp,Response for trial 34,Penn Facial Memory Test
-CPF_A_CPF_trial000034_ttr,CPF_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test
-CPF_A_CPF_trial000034_corr,CPF_q34_corr,Response correct for trial 34,Penn Facial Memory Test
-CPF_A_CPF_trial000035_resp,CPF_q35_resp,Response for trial 35,Penn Facial Memory Test
-CPF_A_CPF_trial000035_ttr,CPF_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test
-CPF_A_CPF_trial000035_corr,CPF_q35_corr,Response correct for trial 35,Penn Facial Memory Test
-CPF_A_CPF_trial000036_resp,CPF_q36_resp,Response for trial 36,Penn Facial Memory Test
-CPF_A_CPF_trial000036_ttr,CPF_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test
-CPF_A_CPF_trial000036_corr,CPF_q36_corr,Response correct for trial 36,Penn Facial Memory Test
-CPF_A_CPF_trial000037_resp,CPF_q37_resp,Response for trial 37,Penn Facial Memory Test
-CPF_A_CPF_trial000037_ttr,CPF_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test
-CPF_A_CPF_trial000037_corr,CPF_q37_corr,Response correct for trial 37,Penn Facial Memory Test
-CPF_A_CPF_trial000038_resp,CPF_q38_resp,Response for trial 38,Penn Facial Memory Test
-CPF_A_CPF_trial000038_ttr,CPF_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test
-CPF_A_CPF_trial000038_corr,CPF_q38_corr,Response correct for trial 38,Penn Facial Memory Test
-CPF_A_CPF_trial000039_resp,CPF_q39_resp,Response for trial 39,Penn Facial Memory Test
-CPF_A_CPF_trial000039_ttr,CPF_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test
-CPF_A_CPF_trial000039_corr,CPF_q39_corr,Response correct for trial 39,Penn Facial Memory Test
-CPF_A_CPF_trial000040_resp,CPF_q40_resp,Response for trial 40,Penn Facial Memory Test
-CPF_A_CPF_trial000040_ttr,CPF_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test
-CPF_A_CPF_trial000040_corr,CPF_q40_corr,Response correct for trial 40,Penn Facial Memory Test
-CPFD_A_ScorVers,CPFD,Current Programming Version of the Scoring Code,Penn Facial Memory Test - Delayed Version
-CPFD_A_status,CPFD_status,Status Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
-CPFD_A_valid_code,CPFD_valid_code,Valid Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TP,CPFD_CPFDTP,CPFD True Positives,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TN,CPFD_CPFDTN,CPFD True Negatives,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_FP,CPFD_CPFDFP,CPFD False Positives,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_FN,CPFD_CPFDFN,CPFD False Negatives,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TPRT,CPFD_CPFDTPRT,CPFD True Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TNRT,CPFD_CPFDTNRT,CPFD True Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_FPRT,CPFD_CPFDFPRT,CPFD False Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_FNRT,CPFD_CPFDFNRT,CPFD False Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_CR,CPFD_DFAC_TOT,CPFD Total Correct Responses,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_RTCR,CPFD_DFAC_RTC,CPFD Median Total Correct Response Time (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_ER,,Total Incorrect Responses,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_RT,,Median Response Time for All Responses (ms),Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000001_RESP,CPFD_q1_resp,Response for trial 1,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000001_TTR,CPFD_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000001_CORR,CPFD_q1_corr,Response correct for trial 1,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000002_RESP,CPFD_q2_resp,Response for trial 2,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000002_TTR,CPFD_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000002_CORR,CPFD_q2_corr,Response correct for trial 2,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000003_RESP,CPFD_q3_resp,Response for trial 3,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000003_TTR,CPFD_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000003_CORR,CPFD_q3_corr,Response correct for trial 3,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000004_RESP,CPFD_q4_resp,Response for trial 4,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000004_TTR,CPFD_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000004_CORR,CPFD_q4_corr,Response correct for trial 4,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000005_RESP,CPFD_q5_resp,Response for trial 5,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000005_TTR,CPFD_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000005_CORR,CPFD_q5_corr,Response correct for trial 5,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000006_RESP,CPFD_q6_resp,Response for trial 6,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000006_TTR,CPFD_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000006_CORR,CPFD_q6_corr,Response correct for trial 6,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000007_RESP,CPFD_q7_resp,Response for trial 7,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000007_TTR,CPFD_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000007_CORR,CPFD_q7_corr,Response correct for trial 7,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000008_RESP,CPFD_q8_resp,Response for trial 8,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000008_TTR,CPFD_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000008_CORR,CPFD_q8_corr,Response correct for trial 8,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000009_RESP,CPFD_q9_resp,Response for trial 9,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000009_TTR,CPFD_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000009_CORR,CPFD_q9_corr,Response correct for trial 9,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000010_RESP,CPFD_q10_resp,Response for trial 10,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000010_TTR,CPFD_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000010_CORR,CPFD_q10_corr,Response correct for trial 10,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000011_RESP,CPFD_q11_resp,Response for trial 11,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000011_TTR,CPFD_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000011_CORR,CPFD_q11_corr,Response correct for trial 11,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000012_RESP,CPFD_q12_resp,Response for trial 12,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000012_TTR,CPFD_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000012_CORR,CPFD_q12_corr,Response correct for trial 12,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000013_RESP,CPFD_q13_resp,Response for trial 13,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000013_TTR,CPFD_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000013_CORR,CPFD_q13_corr,Response correct for trial 13,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000014_RESP,CPFD_q14_resp,Response for trial 14,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000014_TTR,CPFD_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000014_CORR,CPFD_q14_corr,Response correct for trial 14,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000015_RESP,CPFD_q15_resp,Response for trial 15,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000015_TTR,CPFD_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000015_CORR,CPFD_q15_corr,Response correct for trial 15,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000016_RESP,CPFD_q16_resp,Response for trial 16,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000016_TTR,CPFD_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000016_CORR,CPFD_q16_corr,Response correct for trial 16,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000017_RESP,CPFD_q17_resp,Response for trial 17,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000017_TTR,CPFD_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000017_CORR,CPFD_q17_corr,Response correct for trial 17,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000018_RESP,CPFD_q18_resp,Response for trial 18,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000018_TTR,CPFD_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000018_CORR,CPFD_q18_corr,Response correct for trial 18,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000019_RESP,CPFD_q19_resp,Response for trial 19,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000019_TTR,CPFD_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000019_CORR,CPFD_q19_corr,Response correct for trial 19,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000020_RESP,CPFD_q20_resp,Response for trial 20,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000020_TTR,CPFD_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000020_CORR,CPFD_q20_corr,Response correct for trial 20,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000021_RESP,CPFD_q21_resp,Response for trial 21,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000021_TTR,CPFD_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000021_CORR,CPFD_q21_corr,Response correct for trial 21,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000022_RESP,CPFD_q22_resp,Response for trial 22,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000022_TTR,CPFD_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000022_CORR,CPFD_q22_corr,Response correct for trial 22,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000023_RESP,CPFD_q23_resp,Response for trial 23,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000023_TTR,CPFD_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000023_CORR,CPFD_q23_corr,Response correct for trial 23,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000024_RESP,CPFD_q24_resp,Response for trial 24,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000024_TTR,CPFD_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000024_CORR,CPFD_q24_corr,Response correct for trial 24,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000025_RESP,CPFD_q25_resp,Response for trial 25,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000025_TTR,CPFD_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000025_CORR,CPFD_q25_corr,Response correct for trial 25,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000026_RESP,CPFD_q26_resp,Response for trial 26,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000026_TTR,CPFD_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000026_CORR,CPFD_q26_corr,Response correct for trial 26,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000027_RESP,CPFD_q27_resp,Response for trial 27,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000027_TTR,CPFD_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000027_CORR,CPFD_q27_corr,Response correct for trial 27,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000028_RESP,CPFD_q28_resp,Response for trial 28,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000028_TTR,CPFD_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000028_CORR,CPFD_q28_corr,Response correct for trial 28,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000029_RESP,CPFD_q29_resp,Response for trial 29,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000029_TTR,CPFD_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000029_CORR,CPFD_q29_corr,Response correct for trial 29,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000030_RESP,CPFD_q30_resp,Response for trial 30,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000030_TTR,CPFD_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000030_CORR,CPFD_q30_corr,Response correct for trial 30,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000031_RESP,CPFD_q31_resp,Response for trial 31,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000031_TTR,CPFD_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000031_CORR,CPFD_q31_corr,Response correct for trial 31,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000032_RESP,CPFD_q32_resp,Response for trial 32,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000032_TTR,CPFD_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000032_CORR,CPFD_q32_corr,Response correct for trial 32,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000033_RESP,CPFD_q33_resp,Response for trial 33,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000033_TTR,CPFD_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000033_CORR,CPFD_q33_corr,Response correct for trial 33,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000034_RESP,CPFD_q34_resp,Response for trial 34,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000034_TTR,CPFD_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000034_CORR,CPFD_q34_corr,Response correct for trial 34,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000035_RESP,CPFD_q35_resp,Response for trial 35,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000035_TTR,CPFD_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000035_CORR,CPFD_q35_corr,Response correct for trial 35,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000036_RESP,CPFD_q36_resp,Response for trial 36,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000036_TTR,CPFD_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000036_CORR,CPFD_q36_corr,Response correct for trial 36,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000037_RESP,CPFD_q37_resp,Response for trial 37,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000037_TTR,CPFD_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000037_CORR,CPFD_q37_corr,Response correct for trial 37,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000038_RESP,CPFD_q38_resp,Response for trial 38,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000038_TTR,CPFD_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000038_CORR,CPFD_q38_corr,Response correct for trial 38,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000039_RESP,CPFD_q39_resp,Response for trial 39,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000039_TTR,CPFD_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000039_CORR,CPFD_q39_corr,Response correct for trial 39,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000040_RESP,CPFD_q40_resp,Response for trial 40,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000040_TTR,CPFD_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
-CPFD_A_CPFD_TRIAL000040_CORR,CPFD_q40_corr,Response correct for trial 40,Penn Facial Memory Test - Delayed Version
-CPW_A_ScorVers,CPW,Current Programming Version of the Scoring Code,Penn Word Memory Test
-CPW_A_status,CPW_status,Status Code Assigned to CPW,Penn Word Memory Test
-CPW_A_valid_code,CPW_valid_code,Valid Code Assigned to CPW,Penn Word Memory Test
-CPW_A_CPW_TP,CPW_CPWTP,CPW True Positive Responses,Penn Word Memory Test
-CPW_A_CPW_TN,CPW_CPWTN,CPW True Negative Responses,Penn Word Memory Test
-CPW_A_CPW_FP,CPW_CPWFP,CPW False Positive Responses,Penn Word Memory Test
-CPW_A_CPW_FN,CPW_CPWFN,CPW False Negative Responses,Penn Word Memory Test
-CPW_A_CPW_TPRT,CPW_CPWTPRT,Median Response Time for CPW True Positive Responses (ms),Penn Word Memory Test
-CPW_A_CPW_TNRT,CPW_CPWTNRT,Median Response Time for CPW True Negative Responses (ms),Penn Word Memory Test
-CPW_A_CPW_FPRT,CPW_CPWFPRT,Median Response Time for CPW False Positive Responses (ms),Penn Word Memory Test
-CPW_A_CPW_FNRT,CPW_CPWFNRT,Median Response Time for CPW False Negative Responses (ms),Penn Word Memory Test
-CPW_IWRD_TOT,CPW_IWRD_TOT,CPW Total Correct Responses,Penn Word Memory Test
-CPW_IWRD_RTC,CPW_IWRD_RTC,Median Response Time for CPW Total Correct Responses (ms),Penn Word Memory Test
-CPW_A_CPW_trial000001_resp,CPW_q1_resp,Response for trial 1,Penn Word Memory Test
-CPW_A_CPW_trial000001_ttr,CPW_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test
-CPW_A_CPW_trial000001_corr,CPW_q1_corr,Response correct for trial 1,Penn Word Memory Test
-CPW_A_CPW_trial000002_resp,CPW_q2_resp,Response for trial 2,Penn Word Memory Test
-CPW_A_CPW_trial000002_ttr,CPW_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test
-CPW_A_CPW_trial000002_corr,CPW_q2_corr,Response correct for trial 2,Penn Word Memory Test
-CPW_A_CPW_trial000003_resp,CPW_q3_resp,Response for trial 3,Penn Word Memory Test
-CPW_A_CPW_trial000003_ttr,CPW_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test
-CPW_A_CPW_trial000003_corr,CPW_q3_corr,Response correct for trial 3,Penn Word Memory Test
-CPW_A_CPW_trial000004_resp,CPW_q4_resp,Response for trial 4,Penn Word Memory Test
-CPW_A_CPW_trial000004_ttr,CPW_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test
-CPW_A_CPW_trial000004_corr,CPW_q4_corr,Response correct for trial 4,Penn Word Memory Test
-CPW_A_CPW_trial000005_resp,CPW_q5_resp,Response for trial 5,Penn Word Memory Test
-CPW_A_CPW_trial000005_ttr,CPW_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test
-CPW_A_CPW_trial000005_corr,CPW_q5_corr,Response correct for trial 5,Penn Word Memory Test
-CPW_A_CPW_trial000006_resp,CPW_q6_resp,Response for trial 6,Penn Word Memory Test
-CPW_A_CPW_trial000006_ttr,CPW_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test
-CPW_A_CPW_trial000006_corr,CPW_q6_corr,Response correct for trial 6,Penn Word Memory Test
-CPW_A_CPW_trial000007_resp,CPW_q7_resp,Response for trial 7,Penn Word Memory Test
-CPW_A_CPW_trial000007_ttr,CPW_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test
-CPW_A_CPW_trial000007_corr,CPW_q7_corr,Response correct for trial 7,Penn Word Memory Test
-CPW_A_CPW_trial000008_resp,CPW_q8_resp,Response for trial 8,Penn Word Memory Test
-CPW_A_CPW_trial000008_ttr,CPW_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test
-CPW_A_CPW_trial000008_corr,CPW_q8_corr,Response correct for trial 8,Penn Word Memory Test
-CPW_A_CPW_trial000009_resp,CPW_q9_resp,Response for trial 9,Penn Word Memory Test
-CPW_A_CPW_trial000009_ttr,CPW_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test
-CPW_A_CPW_trial000009_corr,CPW_q9_corr,Response correct for trial 9,Penn Word Memory Test
-CPW_A_CPW_trial000010_resp,CPW_q10_resp,Response for trial 10,Penn Word Memory Test
-CPW_A_CPW_trial000010_ttr,CPW_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test
-CPW_A_CPW_trial000010_corr,CPW_q10_corr,Response correct for trial 10,Penn Word Memory Test
-CPW_A_CPW_trial000011_resp,CPW_q11_resp,Response for trial 11,Penn Word Memory Test
-CPW_A_CPW_trial000011_ttr,CPW_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test
-CPW_A_CPW_trial000011_corr,CPW_q11_corr,Response correct for trial 11,Penn Word Memory Test
-CPW_A_CPW_trial000012_resp,CPW_q12_resp,Response for trial 12,Penn Word Memory Test
-CPW_A_CPW_trial000012_ttr,CPW_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test
-CPW_A_CPW_trial000012_corr,CPW_q12_corr,Response correct for trial 12,Penn Word Memory Test
-CPW_A_CPW_trial000013_resp,CPW_q13_resp,Response for trial 13,Penn Word Memory Test
-CPW_A_CPW_trial000013_ttr,CPW_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test
-CPW_A_CPW_trial000013_corr,CPW_q13_corr,Response correct for trial 13,Penn Word Memory Test
-CPW_A_CPW_trial000014_resp,CPW_q14_resp,Response for trial 14,Penn Word Memory Test
-CPW_A_CPW_trial000014_ttr,CPW_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test
-CPW_A_CPW_trial000014_corr,CPW_q14_corr,Response correct for trial 14,Penn Word Memory Test
-CPW_A_CPW_trial000015_resp,CPW_q15_resp,Response for trial 15,Penn Word Memory Test
-CPW_A_CPW_trial000015_ttr,CPW_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test
-CPW_A_CPW_trial000015_corr,CPW_q15_corr,Response correct for trial 15,Penn Word Memory Test
-CPW_A_CPW_trial000016_resp,CPW_q16_resp,Response for trial 16,Penn Word Memory Test
-CPW_A_CPW_trial000016_ttr,CPW_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test
-CPW_A_CPW_trial000016_corr,CPW_q16_corr,Response correct for trial 16,Penn Word Memory Test
-CPW_A_CPW_trial000017_resp,CPW_q17_resp,Response for trial 17,Penn Word Memory Test
-CPW_A_CPW_trial000017_ttr,CPW_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test
-CPW_A_CPW_trial000017_corr,CPW_q17_corr,Response correct for trial 17,Penn Word Memory Test
-CPW_A_CPW_trial000018_resp,CPW_q18_resp,Response for trial 18,Penn Word Memory Test
-CPW_A_CPW_trial000018_ttr,CPW_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test
-CPW_A_CPW_trial000018_corr,CPW_q18_corr,Response correct for trial 18,Penn Word Memory Test
-CPW_A_CPW_trial000019_resp,CPW_q19_resp,Response for trial 19,Penn Word Memory Test
-CPW_A_CPW_trial000019_ttr,CPW_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test
-CPW_A_CPW_trial000019_corr,CPW_q19_corr,Response correct for trial 19,Penn Word Memory Test
-CPW_A_CPW_trial000020_resp,CPW_q20_resp,Response for trial 20,Penn Word Memory Test
-CPW_A_CPW_trial000020_ttr,CPW_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test
-CPW_A_CPW_trial000020_corr,CPW_q20_corr,Response correct for trial 20,Penn Word Memory Test
-CPW_A_CPW_trial000021_resp,CPW_q21_resp,Response for trial 21,Penn Word Memory Test
-CPW_A_CPW_trial000021_ttr,CPW_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test
-CPW_A_CPW_trial000021_corr,CPW_q21_corr,Response correct for trial 21,Penn Word Memory Test
-CPW_A_CPW_trial000022_resp,CPW_q22_resp,Response for trial 22,Penn Word Memory Test
-CPW_A_CPW_trial000022_ttr,CPW_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test
-CPW_A_CPW_trial000022_corr,CPW_q22_corr,Response correct for trial 22,Penn Word Memory Test
-CPW_A_CPW_trial000023_resp,CPW_q23_resp,Response for trial 23,Penn Word Memory Test
-CPW_A_CPW_trial000023_ttr,CPW_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test
-CPW_A_CPW_trial000023_corr,CPW_q23_corr,Response correct for trial 23,Penn Word Memory Test
-CPW_A_CPW_trial000024_resp,CPW_q24_resp,Response for trial 24,Penn Word Memory Test
-CPW_A_CPW_trial000024_ttr,CPW_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test
-CPW_A_CPW_trial000024_corr,CPW_q24_corr,Response correct for trial 24,Penn Word Memory Test
-CPW_A_CPW_trial000025_resp,CPW_q25_resp,Response for trial 25,Penn Word Memory Test
-CPW_A_CPW_trial000025_ttr,CPW_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test
-CPW_A_CPW_trial000025_corr,CPW_q25_corr,Response correct for trial 25,Penn Word Memory Test
-CPW_A_CPW_trial000026_resp,CPW_q26_resp,Response for trial 26,Penn Word Memory Test
-CPW_A_CPW_trial000026_ttr,CPW_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test
-CPW_A_CPW_trial000026_corr,CPW_q26_corr,Response correct for trial 26,Penn Word Memory Test
-CPW_A_CPW_trial000027_resp,CPW_q27_resp,Response for trial 27,Penn Word Memory Test
-CPW_A_CPW_trial000027_ttr,CPW_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test
-CPW_A_CPW_trial000027_corr,CPW_q27_corr,Response correct for trial 27,Penn Word Memory Test
-CPW_A_CPW_trial000028_resp,CPW_q28_resp,Response for trial 28,Penn Word Memory Test
-CPW_A_CPW_trial000028_ttr,CPW_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test
-CPW_A_CPW_trial000028_corr,CPW_q28_corr,Response correct for trial 28,Penn Word Memory Test
-CPW_A_CPW_trial000029_resp,CPW_q29_resp,Response for trial 29,Penn Word Memory Test
-CPW_A_CPW_trial000029_ttr,CPW_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test
-CPW_A_CPW_trial000029_corr,CPW_q29_corr,Response correct for trial 29,Penn Word Memory Test
-CPW_A_CPW_trial000030_resp,CPW_q30_resp,Response for trial 30,Penn Word Memory Test
-CPW_A_CPW_trial000030_ttr,CPW_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test
-CPW_A_CPW_trial000030_corr,CPW_q30_corr,Response correct for trial 30,Penn Word Memory Test
-CPW_A_CPW_trial000031_resp,CPW_q31_resp,Response for trial 31,Penn Word Memory Test
-CPW_A_CPW_trial000031_ttr,CPW_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test
-CPW_A_CPW_trial000031_corr,CPW_q31_corr,Response correct for trial 31,Penn Word Memory Test
-CPW_A_CPW_trial000032_resp,CPW_q32_resp,Response for trial 32,Penn Word Memory Test
-CPW_A_CPW_trial000032_ttr,CPW_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test
-CPW_A_CPW_trial000032_corr,CPW_q32_corr,Response correct for trial 32,Penn Word Memory Test
-CPW_A_CPW_trial000033_resp,CPW_q33_resp,Response for trial 33,Penn Word Memory Test
-CPW_A_CPW_trial000033_ttr,CPW_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test
-CPW_A_CPW_trial000033_corr,CPW_q33_corr,Response correct for trial 33,Penn Word Memory Test
-CPW_A_CPW_trial000034_resp,CPW_q34_resp,Response for trial 34,Penn Word Memory Test
-CPW_A_CPW_trial000034_ttr,CPW_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test
-CPW_A_CPW_trial000034_corr,CPW_q34_corr,Response correct for trial 34,Penn Word Memory Test
-CPW_A_CPW_trial000035_resp,CPW_q35_resp,Response for trial 35,Penn Word Memory Test
-CPW_A_CPW_trial000035_ttr,CPW_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test
-CPW_A_CPW_trial000035_corr,CPW_q35_corr,Response correct for trial 35,Penn Word Memory Test
-CPW_A_CPW_trial000036_resp,CPW_q36_resp,Response for trial 36,Penn Word Memory Test
-CPW_A_CPW_trial000036_ttr,CPW_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test
-CPW_A_CPW_trial000036_corr,CPW_q36_corr,Response correct for trial 36,Penn Word Memory Test
-CPW_A_CPW_trial000037_resp,CPW_q37_resp,Response for trial 37,Penn Word Memory Test
-CPW_A_CPW_trial000037_ttr,CPW_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test
-CPW_A_CPW_trial000037_corr,CPW_q37_corr,Response correct for trial 37,Penn Word Memory Test
-CPW_A_CPW_trial000038_resp,CPW_q38_resp,Response for trial 38,Penn Word Memory Test
-CPW_A_CPW_trial000038_ttr,CPW_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test
-CPW_A_CPW_trial000038_corr,CPW_q38_corr,Response correct for trial 38,Penn Word Memory Test
-CPW_A_CPW_trial000039_resp,CPW_q39_resp,Response for trial 39,Penn Word Memory Test
-CPW_A_CPW_trial000039_ttr,CPW_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test
-CPW_A_CPW_trial000039_corr,CPW_q39_corr,Response correct for trial 39,Penn Word Memory Test
-CPW_A_CPW_trial000040_resp,CPW_q40_resp,Response for trial 40,Penn Word Memory Test
-CPW_A_CPW_trial000040_ttr,CPW_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test
-CPW_A_CPW_trial000040_corr,CPW_q40_corr,Response correct for trial 40,Penn Word Memory Test
-CPWD_A_ScorVers,CPWD,Current Programming Version of the Scoring Code,Penn Word Memory Test - Delayed Version
-CPWD_A_status,CPWD_status,Status Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
-CPWD_A_valid_code,CPWD_valid_code,Valid Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TP,CPWD_CPWDTP,CPWD True Positive Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TN,CPWD_CPWDTN,CPWD True Negative Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_FP,CPWD_CPWDFP,CPWD False Positive Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_FN,CPWD_CPWDFN,CPWD False Negative Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TPRT,CPWD_CPWDTPRT,Median Response Time for CPWD True Positive Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TNRT,CPWD_CPWDTNRT,Median Response Time for CPWD True Negative Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_FPRT,CPWD_CPWDFPRT,Median Response Time for CPWD False Positive Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_FNRT,CPWD_CPWDFNRT,Median Response Time for CPWD False Negative Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_CR,CPWD_DWRD_TOT,CPWD Total Correct Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_RTCR,CPWD_DWRD_RTC,Median Response Time for CPWD Total Correct Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_ER,,Total Incorrect Responses,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_RT,,Median Response Time for All Responses (ms),Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000001_RESP,CPWD_q1_resp,Response for trial 1,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000001_TTR,CPWD_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000001_CORR,CPWD_q1_corr,Response correct for trial 1,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000002_RESP,CPWD_q2_resp,Response for trial 2,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000002_TTR,CPWD_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000002_CORR,CPWD_q2_corr,Response correct for trial 2,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000003_RESP,CPWD_q3_resp,Response for trial 3,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000003_TTR,CPWD_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000003_CORR,CPWD_q3_corr,Response correct for trial 3,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000004_RESP,CPWD_q4_resp,Response for trial 4,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000004_TTR,CPWD_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000004_CORR,CPWD_q4_corr,Response correct for trial 4,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000005_RESP,CPWD_q5_resp,Response for trial 5,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000005_TTR,CPWD_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000005_CORR,CPWD_q5_corr,Response correct for trial 5,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000006_RESP,CPWD_q6_resp,Response for trial 6,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000006_TTR,CPWD_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000006_CORR,CPWD_q6_corr,Response correct for trial 6,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000007_RESP,CPWD_q7_resp,Response for trial 7,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000007_TTR,CPWD_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000007_CORR,CPWD_q7_corr,Response correct for trial 7,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000008_RESP,CPWD_q8_resp,Response for trial 8,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000008_TTR,CPWD_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000008_CORR,CPWD_q8_corr,Response correct for trial 8,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000009_RESP,CPWD_q9_resp,Response for trial 9,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000009_TTR,CPWD_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000009_CORR,CPWD_q9_corr,Response correct for trial 9,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000010_RESP,CPWD_q10_resp,Response for trial 10,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000010_TTR,CPWD_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000010_CORR,CPWD_q10_corr,Response correct for trial 10,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000011_RESP,CPWD_q11_resp,Response for trial 11,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000011_TTR,CPWD_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000011_CORR,CPWD_q11_corr,Response correct for trial 11,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000012_RESP,CPWD_q12_resp,Response for trial 12,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000012_TTR,CPWD_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000012_CORR,CPWD_q12_corr,Response correct for trial 12,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000013_RESP,CPWD_q13_resp,Response for trial 13,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000013_TTR,CPWD_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000013_CORR,CPWD_q13_corr,Response correct for trial 13,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000014_RESP,CPWD_q14_resp,Response for trial 14,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000014_TTR,CPWD_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000014_CORR,CPWD_q14_corr,Response correct for trial 14,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000015_RESP,CPWD_q15_resp,Response for trial 15,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000015_TTR,CPWD_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000015_CORR,CPWD_q15_corr,Response correct for trial 15,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000016_RESP,CPWD_q16_resp,Response for trial 16,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000016_TTR,CPWD_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000016_CORR,CPWD_q16_corr,Response correct for trial 16,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000017_RESP,CPWD_q17_resp,Response for trial 17,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000017_TTR,CPWD_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000017_CORR,CPWD_q17_corr,Response correct for trial 17,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000018_RESP,CPWD_q18_resp,Response for trial 18,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000018_TTR,CPWD_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000018_CORR,CPWD_q18_corr,Response correct for trial 18,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000019_RESP,CPWD_q19_resp,Response for trial 19,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000019_TTR,CPWD_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000019_CORR,CPWD_q19_corr,Response correct for trial 19,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000020_RESP,CPWD_q20_resp,Response for trial 20,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000020_TTR,CPWD_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000020_CORR,CPWD_q20_corr,Response correct for trial 20,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000021_RESP,CPWD_q21_resp,Response for trial 21,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000021_TTR,CPWD_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000021_CORR,CPWD_q21_corr,Response correct for trial 21,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000022_RESP,CPWD_q22_resp,Response for trial 22,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000022_TTR,CPWD_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000022_CORR,CPWD_q22_corr,Response correct for trial 22,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000023_RESP,CPWD_q23_resp,Response for trial 23,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000023_TTR,CPWD_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000023_CORR,CPWD_q23_corr,Response correct for trial 23,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000024_RESP,CPWD_q24_resp,Response for trial 24,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000024_TTR,CPWD_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000024_CORR,CPWD_q24_corr,Response correct for trial 24,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000025_RESP,CPWD_q25_resp,Response for trial 25,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000025_TTR,CPWD_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000025_CORR,CPWD_q25_corr,Response correct for trial 25,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000026_RESP,CPWD_q26_resp,Response for trial 26,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000026_TTR,CPWD_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000026_CORR,CPWD_q26_corr,Response correct for trial 26,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000027_RESP,CPWD_q27_resp,Response for trial 27,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000027_TTR,CPWD_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000027_CORR,CPWD_q27_corr,Response correct for trial 27,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000028_RESP,CPWD_q28_resp,Response for trial 28,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000028_TTR,CPWD_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000028_CORR,CPWD_q28_corr,Response correct for trial 28,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000029_RESP,CPWD_q29_resp,Response for trial 29,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000029_TTR,CPWD_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000029_CORR,CPWD_q29_corr,Response correct for trial 29,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000030_RESP,CPWD_q30_resp,Response for trial 30,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000030_TTR,CPWD_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000030_CORR,CPWD_q30_corr,Response correct for trial 30,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000031_RESP,CPWD_q31_resp,Response for trial 31,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000031_TTR,CPWD_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000031_CORR,CPWD_q31_corr,Response correct for trial 31,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000032_RESP,CPWD_q32_resp,Response for trial 32,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000032_TTR,CPWD_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000032_CORR,CPWD_q32_corr,Response correct for trial 32,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000033_RESP,CPWD_q33_resp,Response for trial 33,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000033_TTR,CPWD_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000033_CORR,CPWD_q33_corr,Response correct for trial 33,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000034_RESP,CPWD_q34_resp,Response for trial 34,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000034_TTR,CPWD_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000034_CORR,CPWD_q34_corr,Response correct for trial 34,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000035_RESP,CPWD_q35_resp,Response for trial 35,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000035_TTR,CPWD_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000035_CORR,CPWD_q35_corr,Response correct for trial 35,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000036_RESP,CPWD_q36_resp,Response for trial 36,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000036_TTR,CPWD_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000036_CORR,CPWD_q36_corr,Response correct for trial 36,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000037_RESP,CPWD_q37_resp,Response for trial 37,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000037_TTR,CPWD_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000037_CORR,CPWD_q37_corr,Response correct for trial 37,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000038_RESP,CPWD_q38_resp,Response for trial 38,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000038_TTR,CPWD_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000038_CORR,CPWD_q38_corr,Response correct for trial 38,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000039_RESP,CPWD_q39_resp,Response for trial 39,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000039_TTR,CPWD_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000039_CORR,CPWD_q39_corr,Response correct for trial 39,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000040_RESP,CPWD_q40_resp,Response for trial 40,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000040_TTR,CPWD_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
-CPWD_A_CPWD_TRIAL000040_CORR,CPWD_q40_corr,Response correct for trial 40,Penn Word Memory Test - Delayed Version
-MPRACT_ScorVers,MPRACT,Current Programming Version of the Scoring Code,Motor Praxis Test
-MPRACT_status,MPRACT_status,Status Code Assigned to Mouse Praxis ,Motor Praxis Test
-MPRACT_valid_code,MPRACT_valid_code,Valid Code Assigned to Mouse Praxis,Motor Praxis Test
-MPRACT_MP1RT,MPRACT_MP1RT,Median Response Time for Mouse Praxis Trial 1 (ms),Motor Praxis Test
-MPRACT_MP2,MPRACT_MP2,Mouse Praxis Correct Responses Trial 2,Motor Praxis Test
-MPRACT_MP2RTCR,MPRACT_MP2RTCR,Median Response Time for Mouse Praxis Trial 2 Correct Responses (ms),Motor Praxis Test
-PCET_A_ScorVers,PCET,Current Programming Version of the Scoring Code,Penn Conditional Exclusion Test - Form A
-PCET_A_status,PCET_status,Status Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
-PCET_A_valid_code,PCET_valid_code,Valid Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CR,PCET_PCETCR,PCET Number Correct Responses,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_RTCR,PCET_PCETRTCR,Median Response Time for PCET Correct Responses (ms),Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_ER,PCET_PCETER,PCET Number Incorrect Responses,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_RTER,PCET_PCETRTER,Median Response Time for PCET Incorrect Responses (ms),Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_WIS_PER_ER,PCET_PER_ER,PCET Number of Perseverative Errors,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_WIS_PER_RES,PCET_PER_RES,PCET Perseverative Errors Plus Correct Perseverative Responses,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_EFF,PCET_PCET_EFF,PCET Efficiency = PCET_ACC/log(PCETRTCR),Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_NUM,PCET_PCET_NUM,Total Number of Trials,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT,PCET_PCET_CAT,Number of PCET Categories Achieved,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT1_TR,PCET_CAT1_tr,Number of Trials Required to Achieve Category 1,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT2_TR,PCET_CAT2_tr,Number of Trials Required to Achieve Category 2,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT3_TR,PCET_CAT3_tr,Number of Trials Required to Achieve Category 3,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_ACC,PCET_PCET_ACC,PCET Accuracy = PCET_CAT * PCETCR/(PCETCR +PCETER),Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_ACC2,PCET_PCET_ACC2,PECT Accuracy2 = (PCET_CAT+1)*PCETCR/(PCETCR+PCETER),Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_RT,,Median Response Time for All Responses (ms),Penn Conditional Exclusion Test - Form A
-PMAT24_A_ScorVers,PMAT,Current Programming Version of the Scoring Code,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_FORM,PMAT24A_PMAT24_FORM,Form of this administration,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_valid_code,PMAT24A_status,Status Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_CR,PMAT24A_valid_code,Valid Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_PC,PMAT24A_PMAT24_A_CR,PMAT24 Correct Responses for Form A,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_SI,PMAT24A_PMAT24_A_SI,PMAT24 Total Skipped Items (items not presented because maximum errors allowed reached) for Form A,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_RTCR,PMAT24A_PMAT24_A_RTCR,Median Response Time for Correct PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_RTER,PMAT24A_PMAT24_A_RTER,Median Response Time for Incorrect PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_RTTO,PMAT24A_PMAT24_A_RTTO,Median Resposne Time for All PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000001_RESP,PMAT24A_q01_resp,Response for trial 1,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000001_TTR,PMAT24A_q01_ttr,Time to respond (ms) for trial 1,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000001_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000001_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000001_CORR,PMAT24A_q01_corr,Response correct for trial 1,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000002_RESP,PMAT24A_q02_resp,Response for trial 2,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000002_TTR,PMAT24A_q02_ttr,Time to respond (ms) for trial 2,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000002_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000002_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000002_CORR,PMAT24A_q02_corr,Response correct for trial 2,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000003_RESP,PMAT24A_q03_resp,Response for trial 3,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000003_TTR,PMAT24A_q03_ttr,Time to respond (ms) for trial 3,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000003_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000003_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000003_CORR,PMAT24A_q03_corr,Response correct for trial 3,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000004_RESP,PMAT24A_q04_resp,Response for trial 4,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000004_TTR,PMAT24A_q04_ttr,Time to respond (ms) for trial 4,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000004_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000004_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000004_CORR,PMAT24A_q04_corr,Response correct for trial 4,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000005_RESP,PMAT24A_q05_resp,Response for trial 5,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000005_TTR,PMAT24A_q05_ttr,Time to respond (ms) for trial 5,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000005_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000005_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000005_CORR,PMAT24A_q05_corr,Response correct for trial 5,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000006_RESP,PMAT24A_q06_resp,Response for trial 6,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000006_TTR,PMAT24A_q06_ttr,Time to respond (ms) for trial 6,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000006_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000006_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000006_CORR,PMAT24A_q06_corr,Response correct for trial 6,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000007_RESP,PMAT24A_q07_resp,Response for trial 7,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000007_TTR,PMAT24A_q07_ttr,Time to respond (ms) for trial 7,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000007_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000007_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000007_CORR,PMAT24A_q07_corr,Response correct for trial 7,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000008_RESP,PMAT24A_q08_resp,Response for trial 8,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000008_TTR,PMAT24A_q08_ttr,Time to respond (ms) for trial 8,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000008_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000008_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000008_CORR,PMAT24A_q08_corr,Response correct for trial 8,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000009_RESP,PMAT24A_q09_resp,Response for trial 9,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000009_TTR,PMAT24A_q09_ttr,Time to respond (ms) for trial 9,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000009_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000009_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000009_CORR,PMAT24A_q09_corr,Response correct for trial 9,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000010_RESP,PMAT24A_q10_resp,Response for trial 10,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000010_TTR,PMAT24A_q10_ttr,Time to respond (ms) for trial 10,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000010_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000010_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000010_CORR,PMAT24A_q10_corr,Response correct for trial 10,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000011_RESP,PMAT24A_q11_resp,Response for trial 11,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000011_TTR,PMAT24A_q11_ttr,Time to respond (ms) for trial 11,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000011_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000011_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000011_CORR,PMAT24A_q11_corr,Response correct for trial 11,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000012_RESP,PMAT24A_q12_resp,Response for trial 12,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000012_TTR,PMAT24A_q12_ttr,Time to respond (ms) for trial 12,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000012_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000012_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000012_CORR,PMAT24A_q12_corr,Response correct for trial 12,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000013_RESP,PMAT24A_q13_resp,Response for trial 13,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000013_TTR,PMAT24A_q13_ttr,Time to respond (ms) for trial 13,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000013_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000013_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000013_CORR,PMAT24A_q13_corr,Response correct for trial 13,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000014_RESP,PMAT24A_q14_resp,Response for trial 14,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000014_TTR,PMAT24A_q14_ttr,Time to respond (ms) for trial 14,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000014_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000014_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000014_CORR,PMAT24A_q14_corr,Response correct for trial 14,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000015_RESP,PMAT24A_q15_resp,Response for trial 15,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000015_TTR,PMAT24A_q15_ttr,Time to respond (ms) for trial 15,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000015_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000015_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000015_CORR,PMAT24A_q15_corr,Response correct for trial 15,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000016_RESP,PMAT24A_q16_resp,Response for trial 16,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000016_TTR,PMAT24A_q16_ttr,Time to respond (ms) for trial 16,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000016_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000016_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000016_CORR,PMAT24A_q16_corr,Response correct for trial 16,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000017_RESP,PMAT24A_q17_resp,Response for trial 17,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000017_TTR,PMAT24A_q17_ttr,Time to respond (ms) for trial 17,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000017_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000017_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000017_CORR,PMAT24A_q17_corr,Response correct for trial 17,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000018_RESP,PMAT24A_q18_resp,Response for trial 18,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000018_TTR,PMAT24A_q18_ttr,Time to respond (ms) for trial 18,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000018_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000018_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000018_CORR,PMAT24A_q18_corr,Response correct for trial 18,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000019_RESP,PMAT24A_q19_resp,Response for trial 19,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000019_TTR,PMAT24A_q19_ttr,Time to respond (ms) for trial 19,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000019_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000019_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000019_CORR,PMAT24A_q19_corr,Response correct for trial 19,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000020_RESP,PMAT24A_q20_resp,Response for trial 20,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000020_TTR,PMAT24A_q20_ttr,Time to respond (ms) for trial 20,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000020_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000020_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000020_CORR,PMAT24A_q20_corr,Response correct for trial 20,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000021_RESP,PMAT24A_q21_resp,Response for trial 21,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000021_TTR,PMAT24A_q21_ttr,Time to respond (ms) for trial 21,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000021_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000021_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000021_CORR,PMAT24A_q21_corr,Response correct for trial 21,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000022_RESP,PMAT24A_q22_resp,Response for trial 22,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000022_TTR,PMAT24A_q22_ttr,Time to respond (ms) for trial 22,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000022_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000022_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000022_CORR,PMAT24A_q22_corr,Response correct for trial 22,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000023_RESP,PMAT24A_q23_resp,Response for trial 23,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000023_TTR,PMAT24A_q23_ttr,Time to respond (ms) for trial 23,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000023_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000023_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000023_CORR,,Response correct for trial 23,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000024_RESP,PMAT24A_q23_corr,Response for trial 24,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000024_TTR,PMAT24A_q24_resp,Time to respond (ms) for trial 24,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000024_TRIAL,PMAT24A_q24_ttr,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000024_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
-PMAT24_A_PMAT24_A_QID000024_CORR,PMAT24A_q24_corr,Response correct for trial 24,Penn Matrix Analysis Test - Form A - 24 items
-PVOC_ScorVers,PVOC_ScorVers,Current Programming Version of the Scoring Code,Penn Vocabulary Test
-PVOC_status,PVOC_status,Status Code Assigned to PVOC,Penn Vocabulary Test
-PVOC_valid_code,PVOC_valid_code,Valid Code Assigned to PVOC,Penn Vocabulary Test
-PVOC_PVOC1,PVOC_PVOC1,PVOC Correct Responses for Items 1-10,Penn Vocabulary Test
-PVOC_PVOC2,PVOC_PVOC2,PVOC Correct Responses for Items 11-20,Penn Vocabulary Test
-PVOC_PVOC3,PVOC_PVOC3,PVOC Correct Responses for Items 21-30,Penn Vocabulary Test
-PVOC_PVOC4,PVOC_PVOC4,PVOC Correct Responses for Items 31-40,Penn Vocabulary Test
-PVOC_PVOC5,PVOC_PVOC5,PVOC Correct Responses for Items 41-50,Penn Vocabulary Test
-PVOC_PVOCCR,PVOC_PVOCCR,PVOC Total Correct Responses,Penn Vocabulary Test
-PVOC_PVOCNR,PVOC_PVOCNR,PVOC Total Non-Responses,Penn Vocabulary Test
-PVOC_PVOC1RTCR,PVOC_PVOC1RTCR,Median Response Time for correct PVOC1 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC2RTCR,PVOC_PVOC2RTCR,Median Response Time for correct PVOC2 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC3RTCR,PVOC_PVOC3RTCR,Median Response Time for correct PVOC3 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC4RTCR,PVOC_PVOC4RTCR,Median Response Time for correct PVOC4 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC5RTCR,PVOC_PVOC5RTCR,Median Response Time for correct PVOC5 Trials (ms),Penn Vocabulary Test
-PVOC_PVOCRTCR,PVOC_PVOCRTCR,Median Response Time for correct PVOC (All Trials) (ms),Penn Vocabulary Test
-PVOC_PVOC1RTER,PVOC_PVOC1RTER,Median Response Time for incorrect PVOC1 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC2RTER,PVOC_PVOC2RTER,Median Response Time for incorrect PVOC2 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC3RTER,PVOC_PVOC3RTER,Median Response Time for incorrect PVOC3 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC4RTER,PVOC_PVOC4RTER,Median Response Time for incorrect PVOC4 Trials (ms),Penn Vocabulary Test
-PVOC_PVOC5RTER,PVOC_PVOC5RTER,Median Response Time for incorrect PVOC5 Trials (ms),Penn Vocabulary Test
-PVOC_PVOCRTER,PVOC_PVOCRTER,Median Response Time for incorrect PVOC (All Trials) (ms),Penn Vocabulary Test
-PVOC_PVOC_Q1,PVOC_PVOC_Q1,PVOC Q1: Were all of the instructions clear?,Penn Vocabulary Test
-PVOC_PVOC_Q2,PVOC_PVOC_Q2,PVOC Q2: Did you have enough time to complete each item?,Penn Vocabulary Test
-PVOC_PVOC_Q3,PVOC_PVOC_Q3,PVOC Q3: Are you a native speaker of English?,Penn Vocabulary Test
-PVOC_PVOC_Q4,PVOC_PVOC_Q4,"PVOC Q4: If no, at what age did you learn English?",Penn Vocabulary Test
-PVOC_PVOC_Q5,PVOC_PVOC_Q5,PVOC Q5: Most recent Verbal SAT score,Penn Vocabulary Test
-PVOC_PVOC_Q6,PVOC_PVOC_Q6,PVOC Q6: Most recent Math SAT score,Penn Vocabulary Test
-PVOC_PVOC_Q7,PVOC_PVOC_Q7,PVOC Q7: SAT Year Taken,Penn Vocabulary Test
-PVOC_RES_1,PVOC_RES_1,Response for Item 1,Penn Vocabulary Test
-PVOC_RES_2,PVOC_RES_2,Response for Item 2,Penn Vocabulary Test
-PVOC_RES_3,PVOC_RES_3,Response for Item 3,Penn Vocabulary Test
-PVOC_RES_4,PVOC_RES_4,Response for Item 4,Penn Vocabulary Test
-PVOC_RES_5,PVOC_RES_5,Response for Item 5,Penn Vocabulary Test
-PVOC_RES_6,PVOC_RES_6,Response for Item 6,Penn Vocabulary Test
-PVOC_RES_7,PVOC_RES_7,Response for Item 7,Penn Vocabulary Test
-PVOC_RES_8,PVOC_RES_8,Response for Item 8,Penn Vocabulary Test
-PVOC_RES_9,PVOC_RES_9,Response for Item 9,Penn Vocabulary Test
-PVOC_RES_10,PVOC_RES_10,Response for Item 10,Penn Vocabulary Test
-PVOC_RES_11,PVOC_RES_11,Response for Item 11,Penn Vocabulary Test
-PVOC_RES_12,PVOC_RES_12,Response for Item 12,Penn Vocabulary Test
-PVOC_RES_13,PVOC_RES_13,Response for Item 13,Penn Vocabulary Test
-PVOC_RES_14,PVOC_RES_14,Response for Item 14,Penn Vocabulary Test
-PVOC_RES_15,PVOC_RES_15,Response for Item 15,Penn Vocabulary Test
-PVOC_RES_16,PVOC_RES_16,Response for Item 16,Penn Vocabulary Test
-PVOC_RES_17,PVOC_RES_17,Response for Item 17,Penn Vocabulary Test
-PVOC_RES_18,PVOC_RES_18,Response for Item 18,Penn Vocabulary Test
-PVOC_RES_19,PVOC_RES_19,Response for Item 19,Penn Vocabulary Test
-PVOC_RES_20,PVOC_RES_20,Response for Item 20,Penn Vocabulary Test
-PVOC_RES_21,PVOC_RES_21,Response for Item 21,Penn Vocabulary Test
-PVOC_RES_22,PVOC_RES_22,Response for Item 22,Penn Vocabulary Test
-PVOC_RES_23,PVOC_RES_23,Response for Item 23,Penn Vocabulary Test
-PVOC_RES_24,PVOC_RES_24,Response for Item 24,Penn Vocabulary Test
-PVOC_RES_25,PVOC_RES_25,Response for Item 25,Penn Vocabulary Test
-PVOC_RES_26,PVOC_RES_26,Response for Item 26,Penn Vocabulary Test
-PVOC_RES_27,PVOC_RES_27,Response for Item 27,Penn Vocabulary Test
-PVOC_RES_28,PVOC_RES_28,Response for Item 28,Penn Vocabulary Test
-PVOC_RES_29,PVOC_RES_29,Response for Item 29,Penn Vocabulary Test
-PVOC_RES_30,PVOC_RES_30,Response for Item 30,Penn Vocabulary Test
-PVOC_RES_31,PVOC_RES_31,Response for Item 31,Penn Vocabulary Test
-PVOC_RES_32,PVOC_RES_32,Response for Item 32,Penn Vocabulary Test
-PVOC_RES_33,PVOC_RES_33,Response for Item 33,Penn Vocabulary Test
-PVOC_RES_34,PVOC_RES_34,Response for Item 34,Penn Vocabulary Test
-PVOC_RES_35,PVOC_RES_35,Response for Item 35,Penn Vocabulary Test
-PVOC_RES_36,PVOC_RES_36,Response for Item 36,Penn Vocabulary Test
-PVOC_RES_37,PVOC_RES_37,Response for Item 37,Penn Vocabulary Test
-PVOC_RES_38,PVOC_RES_38,Response for Item 38,Penn Vocabulary Test
-PVOC_RES_39,PVOC_RES_39,Response for Item 39,Penn Vocabulary Test
-PVOC_RES_40,PVOC_RES_40,Response for Item 40,Penn Vocabulary Test
-PVOC_RES_41,PVOC_RES_41,Response for Item 41,Penn Vocabulary Test
-PVOC_RES_42,PVOC_RES_42,Response for Item 42,Penn Vocabulary Test
-PVOC_RES_43,PVOC_RES_43,Response for Item 43,Penn Vocabulary Test
-PVOC_RES_44,PVOC_RES_44,Response for Item 44,Penn Vocabulary Test
-PVOC_RES_45,PVOC_RES_45,Response for Item 45,Penn Vocabulary Test
-PVOC_RES_46,PVOC_RES_46,Response for Item 46,Penn Vocabulary Test
-PVOC_RES_47,PVOC_RES_47,Response for Item 47,Penn Vocabulary Test
-PVOC_RES_48,PVOC_RES_48,Response for Item 48,Penn Vocabulary Test
-PVOC_RES_49,PVOC_RES_49,Response for Item 49,Penn Vocabulary Test
-PVOC_RES_50,PVOC_RES_50,Response for Item 50,Penn Vocabulary Test
-PVRT_ScorVers,SPVRT,Current Programming Version of the Scoring Code,Penn Logical Reasoning Test - Short Version
-PVRT_PVRT_Form,PVRT_form,Form of the PVRT,Penn Logical Reasoning Test - Short Version
-PVRT_Status,PVRT_status,Status Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_valid_code,PVRT_valid_code,Valid Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_PVRTCR,PVRT_PVRTCR,Correct Responses for SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_PVRT_PC,PVRT_PVRT_PC,Percent Correct for SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_PVRTRTTO,PVRT_PVRTRTTO,All Responses Median Response Time (ms) for SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_PVRTRTCR,PVRT_PVRTRTCR,SPVRT Median Response Time for Correct Responses (ms),Penn Logical Reasoning Test - Short Version
-PVRT_PVRTRTER,PVRT_PVRTRTER,SPVRT Median Response Time for Incorrect Responses (ms),Penn Logical Reasoning Test - Short Version
-PVRT_PVRT_EFF,PVRT_PVRT_EFF,PVRT Efficiency = PVRT_PC/log(PVRTRTCR),Penn Logical Reasoning Test - Short Version
-SVOLT_A_ScorVers,SVOLT,Current Programming Version of the Scoring Code,Visual Object Learning Test - Short Version
-SVOLT_A_status,SHORTVOLT_status,Status Code Assigned to SVOLT,Visual Object Learning Test - Short Version
-SVOLT_A_valid_code,SHORTVOLT_valid_code,Valid Code Assigned to SVOLT,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_CR,SHORTVOLT_SVT,SVOLT Total Correct,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_RT,SHORTVOLT_SVTRT,Median Response Time for Short VOLT All Responses (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_CRT,SHORTVOLT_SVTCRT,Median Response Time for SVOLT Correct Responses (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_IRT,SHORTVOLT_SVTIRT,Median Response Time for SVOLT Incorrect Responses (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_TP,SHORTVOLT_SVTTP,SVOLT True Positive Responses,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_TN,SHORTVOLT_SVTTN,SVOLT True Negative Responses,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_FP,SHORTVOLT_SVTFP,SVOLT False Positive Responses,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_FN,SHORTVOLT_SVTFN,SVOLT False Negative Responses,Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_TPRT,SHORTVOLT_SVTTPRT,SVOLT True Positive Median Response Time (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_TNRT,SHORTVOLT_SVTTNRT,SVOLT True Negative Median Response Time (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_FPRT,SHORTVOLT_SVTFPRT,SVOLT False Positive Median Response Time (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_FNRT,SHORTVOLT_SVTFNRT,SVOLT False Negative Median Response Time (ms),Visual Object Learning Test - Short Version
-SVOLT_A_SVOLT_EFF,SHORTVOLT_SVT_EFF,Short VOLT Efficiency ,Visual Object Learning Test - Short Version
-SPCPTNL_ScorVers,SPCPTNL,Current Programming Version of the Scoring Code,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_status,SPCPTNL_status,Status Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_valid_code,SPCPTNL_valid_code,Valid Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_TP,SPCPTNL_SCPN_TP,NumLet True Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_FP,SPCPTNL_SCPN_FP,NumLet False Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_TN,SPCPTNL_SCPN_TN,NumLet True Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_FN,SPCPTNL_SCPN_FN,NumLet False Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_TPRT,SPCPTNL_SCPN_TPRT,Median Response Time for NumLet True Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_FPRT,SPCPTNL_SCPN_FPRT,Median Response Time for NumLet False Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_TP,SPCPTNL_SCPL_TP,NumLet True Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_FP,SPCPTNL_SCPL_FP,NumLet False Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_TN,SPCPTNL_SCPL_TN,NumLet True Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_FN,SPCPTNL_SCPL_FN,NumLet False Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_TPRT,SPCPTNL_SCPL_TPRT,Median Response Time for NumLet True Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_FPRT,SPCPTNL_SCPL_FPRT,Median Response Time for NumLet False Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_FN,SPCPTNL_SCPT_FN,NumLet CPT False Negatives - Sum of SCPN_FN and SCPL_FN,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_FP,SPCPTNL_SCPT_FP,NumLet CPT False Positives - Sum of SCPN_FP and SCPL_FP,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_TP,SPCPTNL_SCPT_TP,NumLet CPT True Positives - Sum of SCPN_TP and SCPL_TP,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_TN,SPCPTNL_SCPT_TN,NumLet CPT True Negatives - Sum of SCPN_TN and SCPL_TN,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_TPRT,SPCPTNL_SCPT_TPRT,Median Response Time for NumLet True Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_FPRT,SPCPTNL_SCPT_FPRT,Median Response Time for NumLet False Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPN_RT,,Median Response Time for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPL_RT,,Median Response Time for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_RT,,Median Response Time for All Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_SEN,,Sensitivity = SCPT_TP/(SCPT_TP + SCPT_FN),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_SPEC,,Specificity = SCPT_TN/(SCPT_TN + SCPT_FP),Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_LRNR,SPCPTNL_SCPT_LRNR,NumLet CPT Longest Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
-SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,NumLet CPT Final Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
-SVOLTD_A_ScorVers,SVOLTD,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_status,SVDELAY_status,Status Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_valid_code,SVDELAY_valid_code,Valid Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVTLDRTC,SVDELAY_SVTLDRTC,Median Response Time for SVOLTD Correct Responses (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVTLDRTER,SVDELAY_SVTLDRTER,Median Response Time for SVOLTD Incorrect Responses (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTP,SVDELAY_SVT_LDTP,SVOLTD True Positive Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTN,SVDELAY_SVT_LDTN,SVOLTD True Negative Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFP,SVDELAY_SVT_LDFP,SVOLTD False Positive Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFN,SVDELAY_SVT_LDFN,SVOLTD False Negative Responses,Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTPRT,SVDELAY_SVT_LDTPRT,SVOLTD True Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
-SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
-SFNB2_ScorVers,SFNB2,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
-SFNB2_status,SFNB2_status,SFNB2 completion status,Short Fractal-N-Back- 2 Back Version
-SFNB2_valid_code,SFNB2_valid_code,SFNB2 valid code,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TP,SFNB2_SFNB_TP,SFNB2 True Positive Responses,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FP,SFNB2_SFNB_FP,SFNB2 False Positive Responses,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_RTC,SFNB2_SFNB_RTC,SFNB2 Median Response Time for All Correct Responses (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TP0,SFNB2_SFNB_TP0,SFNB2 True Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FP0,SFNB2_SFNB_FP0,SFNB2 False Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_RTC0,SFNB2_SFNB_RTC0,SFNB2 Median Response Time for Correct 0-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TP1,SFNB2_SFNB_TP1,SFNB2 True Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FP1,SFNB2_SFNB_FP1,SFNB2 False Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_RTC1,SFNB2_SFNB_RTC1,SFNB2 Median Response Time for Correct 1-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TP2,SFNB2_SFNB_TP2,SFNB2 True Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FP2,SFNB2_SFNB_FP2,SFNB2 False Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TN0,SFNB2_SFNB_TN0,SFNB2 True Negative Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TN1,SFNB2_SFNB_TN1,SFNB2 True Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_TN2,SFNB2_SFNB_TN2,SFNB2 True Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FN1,SFNB2_SFNB_FN1,SFNB2 False Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_FN2,SFNB2_SFNB_FN2,SFNB2 False Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_RTC2,SFNB2_SFNB_RTC2,SFNB2 Median Response Time for Correct 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MCR,SFNB2_SFNB_MCR,SFNB2 True Positive Reponses for 1-Back and 2-Back Trials,Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MRTC,SFNB2_SFNB_MRTC,SFNB2 Mean of Median RT for True Positive Responses for 1-Back and for 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MRT,SFNB2_SFNB_MRT,SFNB2 Median Response Time for All Responses (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MEFF,SFNB2_SFNB_MEFF,SFNB2 Efficiency = SFNB_MCR/log(SFNB_MRTC),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MSEN,,SFNB2 Sensitivity = (SFNB_TP1 + SFNB_TP2)/(SFNB_TP1 + SFNB_TP2 +SFNB_FN1 + SFNB_FN2),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MSPEC,,SFNB2 Specificity = (SFNB_TN1 + SFNB_TN2)/(SFNB_TN1 + SFNB_TN2 +SFNB_FP1 + SFNB_FP2),Short Fractal-N-Back- 2 Back Version
-ER40_D_ScorVers,ER40D,Current Programming Version of the Scoring Code,Emotion Recognition Task- Form D- 40 items 
-ER40_D_status,ER40D_status,ER40 completion status,Emotion Recognition Task- Form D- 40 items 
-ER40_D_valid_code,ER40D_valid_code,ER40 valid code,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_CR,ER40D_ER40_CR,ER40 Correct Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_RTCR,ER40D_ER40_CRT,ER40 Correct Responses Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_RT,,Median Response Time for All Trials (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FC,ER40D_ER40_FC,ER40 Correct Female Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MC,ER40D_ER40_MC,ER40 Correct Male Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FCRT,ER40D_ER40FCRT,ER40 Correct Female Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MCRT,ER40D_ER40MCRT,ER40 Correct Male Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_ANG,ER40D_ER40ANG,ER40 Correct Anger Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FEAR,ER40D_ER40FEAR,ER40 Correct Fear Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_HAP,ER40D_ER40HAP,ER40 Correct Happy Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_NOE,ER40D_ER40NOE,ER40 Correct No Emotion Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_SAD,ER40D_ER40SAD,ER40 Correct Sad Identifications,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FACR,ER40D_ER40FACR,ER40 Correct Anger Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FFCR,ER40D_ER40FFCR,ER40 Correct Fear Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FHCR,ER40D_ER40FHCR,ER40 Correct Happy Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FNCR,ER40D_ER40FNCR,ER40 Correct No Emotion Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FSCR,ER40D_ER40FSCR,ER40 Correct Sad Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MACR,ER40D_ER40MACR,ER40 Correct Anger Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MFCR,ER40D_ER40MFCR,ER40 Correct Fear Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MHCR,ER40D_ER40MHCR,ER40 Correct Happy Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MNCR,ER40D_ER40MNCR,ER40 Correct No Emotion Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MSCR,ER40D_ER40MSCR,ER40 Correct Sad Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPA,ER40D_ER40_FPA,ER40 False Positive Anger Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPF,ER40D_ER40_FPF,ER40 False Positive Fear Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPH,ER40D_ER40_FPH,ER40 False Positive Happy Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPN,ER40D_ER40_FPN,ER40 False Positive No Emotion Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPS,ER40D_ER40_FPS,ER40 False Positive Sad Responses,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_ANGRT,ER40D_ER40ANGRT,Median Response Time for ER40 Correct Anger Identifications (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FEARRT,ER40D_ER40FEARRT,Median Response Time for ER40 Correct Fear Identifications (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_HAPRT,ER40D_ER40HAPRT,Median Response Time for ER40 Correct Happy Identifications (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_NOERT,ER40D_ER40NOERT,Median Response Time for ER40 Correct No Emotion Identifications (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_SADRT,ER40D_ER40SADRT,Median Response Time for ER40 Correct Sad Identifications (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FART,ER40D_ER40FART,Median Response Time for ER40 Correct Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FFRT,ER40D_ER40FFRT,Median Response Time for ER40 Correct Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FHRT,ER40D_ER40FHRT,Median Response Time for ER40 Correct Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FNRT,ER40D_ER40FNRT,Median Response Time for ER40 Correct No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FSRT,ER40D_ER40FSRT,Median Response Time for ER40 Correct Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MART,ER40D_ER40MART,Median Response Time for ER40 Correct Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MFRT,ER40D_ER40MFRT,Median Response Time for ER40 Correct Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MHRT,ER40D_ER40MHRT,Median Response Time for ER40 Correct Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MNRT,ER40D_ER40MNRT,Median Response Time for ER40 Correct No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MSRT,ER40D_ER40MSRT,Median Response Time for ER40 Correct Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FAERT,ER40D_ER40FAERT,Median Response Time for ER40 Incorrect Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FFERT,ER40D_ER40FFERT,Median Response Time for ER40 Incorrect Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FHERT,ER40D_ER40FHERT,Median Response Time for ER40 Incorrect Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FNERT,ER40D_ER40FNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FSERT,ER40D_ER40FSERT,Median Response Time for ER40 Incorrect Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MAERT,ER40D_ER40MAERT,Median Response Time for ER40 Incorrect Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MFERT,ER40D_ER40MFERT,Median Response Time for ER40 Incorrect Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MHERT,ER40D_ER40MHERT,Median Response Time for ER40 Incorrect Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MNERT,ER40D_ER40MNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_MSERT,ER40D_ER40MSERT,Median Response Time for ER40 Incorrect Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPART,ER40D_ER40_FPART,Median Response Time for ER40 False Positive Anger Responses (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPFRT,ER40D_ER40_FPFRT,Median Response Time for ER40 False Positive Fear Responses (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPHRT,ER40D_ER40_FPHRT,Median Response Time for ER40 False Positive Happy Responses (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPNRT,ER40D_ER40_FPNRT,Median Response Time for ER40 False Positive No Emotion Responses (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_FPSRT,ER40D_ER40_FPSRT,Median Response Time for ER40 False Positive Sad Responses (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_CACR,ER40D_ER40CACR,ER40 Correct Identifications of Caucasian faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_AACR,ER40D_ER40AACR,ER40 Correct Identifications of African American faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_OTHCR,ER40D_ER40OTHCR,ER40 Correct Identifications of Other Race faces,Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_CACRT,ER40D_ER40CACRT,ER40 Median Response Time for Correct Identifications of Caucasian faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_AACRT,ER40D_ER40AACRT,ER40 Median Response Time for Correct Identifications of African American faces (ms),Emotion Recognition Task- Form D- 40 items 
-ER40_D_ER40D_OTHCRT,ER40D_ER40OTHCRT,ER40 Median Response Time for Correct Identifications of Other Race faces (ms),Emotion Recognition Task- Form D- 40 items 
-MEDF36_A_ScorVers,MEDF36,Current Programming Version of the Scoring Code,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_status,MEDF36_status,MEDF36 completion status,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_valid_code,MEDF36_valid_code,MEDF36 valid code,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_CR,MEDF36_MEDF36_A,Total Correct Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PC,,Percent Correct Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_RTCR,MEDF36_MEDF36_T,Median Response Time for All Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_ER,,Total Incorrect Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_RTER,,Median Response Time for Incorrect Responses (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_ANG_CR,MEDF36_MEDF36_ANG_CR,Correct Responses for Measured Emodiff Angry Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_ANG_RTCR,MEDF36_MEDF36_ANG_RTCR,Median Response Time for Correct Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_ANG_ER,,Total Incorrect Anger Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_ANG_RTER,MEDF36_MEDF36_ANG_RTER,Median Response Time for Incorrect Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_CA_CR,,Total Correct Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_CA_RTCR,,Median Response Time for Correct Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT10_CR,,Total Correct 10 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT10_RTCR,,Median Response Time for Correct 10 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT20_CR,,Total Correct 20 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT20_RTCR,,Median Response Time for Correct 20 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT30_CR,,Total Correct 30 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT30_RTCR,,Median Response Time for Correct 30 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT40_CR,,Total Correct 40 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT40_RTCR,,Median Response Time for Correct 40 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT50_CR,,Total Correct 50 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT50_RTCR,,Median Response Time for Correct 50 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT60_CR,,Total Correct 60 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_PCT60_RTCR,,Median Response Time for Correct 60 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEAR_CR,MEDF36_MEDF36_FEAR_CR,Correct Responses for Measured Emodiff Fear Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEAR_RTCR,MEDF36_MEDF36_FEAR_RTCR,Median Response Time for Correct Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEAR_ER,,Total Incorrect Fear Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEAR_RTER,MEDF36_MEDF36_FEAR_RTER,Median Response Time for Incorrect Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEMALE_CR,,Total Correct Female Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_FEMALE_RTCR,,Median Response Time for Correct Female Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_HAP_CR,MEDF36_MEDF36_HAP_CR,Correct Responses for Measured Emodiff Happy Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_HAP_RTCR,MEDF36_MEDF36_HAP_RTCR,Median Response Time for Correct Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_HAP_ER,,Total Incorrect Happy Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_HAP_RTER,MEDF36_MEDF36_HAP_RTER,Median Response Time for Incorrect Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_MALE_CR,,Total Correct Male Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_MALE_RTCR,,Median Response Time for Correct Male Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_NONCA_CR,,Total Correct Non-Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_NONCA_RTCR,,Median Response Time for Correct Non-Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_NS_CR,MEDF36_MEDF36_NS_CR,"Total Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_NS_RTCR,MEDF36_MEDF36_NS_RTCR,"Median Response Time for Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAD_CR,MEDF36_MEDF36_SAD_CR,Correct Responses for Measured Emodiff Sad Trials,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAD_RTCR,MEDF36_MEDF36_SAD_RTCR,Median Response Time for Correct Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAD_ER,,Total Incorrect Sad Trial Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAD_RTER,MEDF36_MEDF36_SAD_RTER,Median Response Time for Incorrect Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAME_CR,MEDF36_MEDF36_SAME_CR,Total Incorrect Anger Same (No Difference) Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_RTCR,Median Response Time for Correct Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items
+survey_var,survey_var_old,evioni_var,description,test
+test_sessions_datasetid,test_sessions_datasetid,test_sessions_datasetid,Unique Number for that CNB,Test Sessions
+test_sessions_siteid,test_sessions_siteid,test_sessions_siteid,Site ID battery was administered to,Test Sessions
+test_sessions_famid,test_sessions_famid,test_sessions_famid,Family ID battery was administered to,Test Sessions
+test_sessions_subid,test_sessions_subid,test_sessions_subid,Subject ID battery was administered to,Test Sessions
+test_sessions_v_bblid,test_sessions_bblid,test_sessions_bblid,BBLID battery was administered to,Test Sessions
+test_sessions_v_battery,test_sessions_v_battery,test_sessions_battery,Battery Name,Test Sessions
+test_sessions_v_age,test_sessions_v_age,test_sessions_age,Age of participant,Test Sessions
+test_sessions_v_gender,test_sessions_v_gender,test_sessions_gender,Gender of participant,Test Sessions
+test_sessions_v_dotest,test_sessions_v_dotest,test_sessions_dotest,Date of CNB,Test Sessions
+test_sessions_v_dob,test_sessions_v_dob,test_sessions_dob,Date of Birth of participant,Test Sessions
+test_sessions_v_handedness,test_sessions_v_handedness,test_sessions_handedness,Handedness of participant,Test Sessions
+test_sessions_v_education,test_sessions_v_education,test_sessions_education,Highest Level of Education of participant,Test Sessions
+test_sessions_v_feducation,test_sessions_v_feducation,test_sessions_feducation,Highest Level of Education of participant's father,Test Sessions
+test_sessions_v_meducation,test_sessions_v_meducation,test_sessions_meducation,Highest Level of Education of participant's mother,Test Sessions
+test_sessions_v_admin_comments,test_sessions_v_admin_comments,test_sessions_admin_comments,Administrator Comments,Test Sessions
+test_sessions_v_valid_code,test_sessions_v_valid_code,test_sessions_valid_code,Validation Code Assigned,Test Sessions
+CPF_A_ScorVers,CPF_ScorVers,CPF,Current Programming Version of the Scoring Code,Penn Facial Memory Test
+CPF_A_status,CPF_status,CPF_status,Status Code Assigned to CPF,Penn Facial Memory Test
+CPF_A_valid_code,CPF_valid_code,CPF_valid_code,Valid Code Assigned to CPF,Penn Facial Memory Test
+CPF_A_CPF_TP,CPF_CPFTP,CPF_CPFTP,CPF True Positives,Penn Facial Memory Test
+CPF_A_CPF_TN,CPF_CPFTN,CPF_CPFTN,CPF True Negatives,Penn Facial Memory Test
+CPF_A_CPF_FP,CPF_CPFFP,CPF_CPFFP,CPF False Positives,Penn Facial Memory Test
+CPF_A_CPF_FN,CPF_CPFFN,CPF_CPFFN,CPF False Negatives,Penn Facial Memory Test
+CPF_A_CPF_TPRT,CPF_CPFTPRT,CPF_CPFTPRT,CPF True Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_TNRT,CPF_CPFTNRT,CPF_CPFTNRT,CPF True Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_FPRT,CPF_CPFFPRT,CPF_CPFFPRT,CPF False Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_FNRT,CPF_CPFFNRT,CPF_CPFFNRT,CPF False Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_CR,CPF_IFAC_TOT,CPF_IFAC_TOT,CPF Total Correct Responses,Penn Facial Memory Test
+CPF_A_CPF_W_RTCR,CPF_IFAC_RTC,CPF_IFAC_RTC,CPF Weighted Median Total Correct Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_RTCR,,,CPF Median Response Total Correct Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_ER,,,Total Incorrect Responses,Penn Facial Memory Test
+CPF_A_CPF_RTER,,,Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test
+CPF_A_CPF_W_RTER,,,Weighted Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test
+CPF_A_CPF_RT,,,Median Response Time for All Responses (ms),Penn Facial Memory Test
+CPF_A_CPF_DY,,,Total Definitely Yes Responses,Penn Facial Memory Test
+CPF_A_CPF_DN,,,Total Definitely No Responses,Penn Facial Memory Test
+CPF_A_CPF_PY,,,Total Probably Yes Responses,Penn Facial Memory Test
+CPF_A_CPF_PN,,,Total Probably No Responses,Penn Facial Memory Test
+CPF_A_CPF_DTP,,,Total Definitely True Positive Responses,Penn Facial Memory Test
+CPF_A_CPF_PTP,,,Total Probably True Positive Responses,Penn Facial Memory Test
+CPF_A_CPF_DTN,,,Total Definitely True Negative Responses,Penn Facial Memory Test
+CPF_A_CPF_PTN,,,Total Probably True Negative Responses,Penn Facial Memory Test
+CPF_A_CPF_DFP,,,Total Definitely False Positive Responses,Penn Facial Memory Test
+CPF_A_CPF_EFF,,,CPF_A VOLT Efficiency ,Penn Facial Memory Test
+CPF_A_CPF_DFN,,,Total Definitely False Negative Responses,Penn Facial Memory Test
+CPF_A_CPF_PFN,,,Total Probably False Negative Responses,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000001_RESP,CPF_q1_resp,CPF_q1_resp,Response for trial 1,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000001_TTR,CPF_q1_ttr,CPF_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000001_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000001_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000001_CORR,CPF_q1_corr,CPF_q1_corr,Response correct for trial 1,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000002_RESP,CPF_q2_resp,CPF_q2_resp,Response for trial 2,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000002_TTR,CPF_q2_ttr,CPF_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000002_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000002_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000002_CORR,CPF_q2_corr,CPF_q2_corr,Response correct for trial 2,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000003_RESP,CPF_q3_resp,CPF_q3_resp,Response for trial 3,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000003_TTR,CPF_q3_ttr,CPF_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000003_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000003_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000003_CORR,CPF_q3_corr,CPF_q3_corr,Response correct for trial 3,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000004_RESP,CPF_q4_resp,CPF_q4_resp,Response for trial 4,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000004_TTR,CPF_q4_ttr,CPF_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000004_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000004_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000004_CORR,CPF_q4_corr,CPF_q4_corr,Response correct for trial 4,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000005_RESP,CPF_q5_resp,CPF_q5_resp,Response for trial 5,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000005_TTR,CPF_q5_ttr,CPF_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000005_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000005_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000005_CORR,CPF_q5_corr,CPF_q5_corr,Response correct for trial 5,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000006_RESP,CPF_q6_resp,CPF_q6_resp,Response for trial 6,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000006_TTR,CPF_q6_ttr,CPF_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000006_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000006_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000006_CORR,CPF_q6_corr,CPF_q6_corr,Response correct for trial 6,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000007_RESP,CPF_q7_resp,CPF_q7_resp,Response for trial 7,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000007_TTR,CPF_q7_ttr,CPF_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000007_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000007_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000007_CORR,CPF_q7_corr,CPF_q7_corr,Response correct for trial 7,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000008_RESP,CPF_q8_resp,CPF_q8_resp,Response for trial 8,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000008_TTR,CPF_q8_ttr,CPF_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000008_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000008_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000008_CORR,CPF_q8_corr,CPF_q8_corr,Response correct for trial 8,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000009_RESP,CPF_q9_resp,CPF_q9_resp,Response for trial 9,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000009_TTR,CPF_q9_ttr,CPF_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000009_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000009_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000009_CORR,CPF_q9_corr,CPF_q9_corr,Response correct for trial 9,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000010_RESP,CPF_q10_resp,CPF_q10_resp,Response for trial 10,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000010_TTR,CPF_q10_ttr,CPF_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000010_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000010_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000010_CORR,CPF_q10_corr,CPF_q10_corr,Response correct for trial 10,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000011_RESP,CPF_q11_resp,CPF_q11_resp,Response for trial 11,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000011_TTR,CPF_q11_ttr,CPF_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000011_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000011_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000011_CORR,CPF_q11_corr,CPF_q11_corr,Response correct for trial 11,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000012_RESP,CPF_q12_resp,CPF_q12_resp,Response for trial 12,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000012_TTR,CPF_q12_ttr,CPF_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000012_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000012_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000012_CORR,CPF_q12_corr,CPF_q12_corr,Response correct for trial 12,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000013_RESP,CPF_q13_resp,CPF_q13_resp,Response for trial 13,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000013_TTR,CPF_q13_ttr,CPF_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000013_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000013_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000013_CORR,CPF_q13_corr,CPF_q13_corr,Response correct for trial 13,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000014_RESP,CPF_q14_resp,CPF_q14_resp,Response for trial 14,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000014_TTR,CPF_q14_ttr,CPF_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000014_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000014_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000014_CORR,CPF_q14_corr,CPF_q14_corr,Response correct for trial 14,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000015_RESP,CPF_q15_resp,CPF_q15_resp,Response for trial 15,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000015_TTR,CPF_q15_ttr,CPF_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000015_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000015_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000015_CORR,CPF_q15_corr,CPF_q15_corr,Response correct for trial 15,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000016_RESP,CPF_q16_resp,CPF_q16_resp,Response for trial 16,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000016_TTR,CPF_q16_ttr,CPF_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000016_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000016_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000016_CORR,CPF_q16_corr,CPF_q16_corr,Response correct for trial 16,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000017_RESP,CPF_q17_resp,CPF_q17_resp,Response for trial 17,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000017_TTR,CPF_q17_ttr,CPF_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000017_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000017_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000017_CORR,CPF_q17_corr,CPF_q17_corr,Response correct for trial 17,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000018_RESP,CPF_q18_resp,CPF_q18_resp,Response for trial 18,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000018_TTR,CPF_q18_ttr,CPF_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000018_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000018_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000018_CORR,CPF_q18_corr,CPF_q18_corr,Response correct for trial 18,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000019_RESP,CPF_q19_resp,CPF_q19_resp,Response for trial 19,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000019_TTR,CPF_q19_ttr,CPF_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000019_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000019_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000019_CORR,CPF_q19_corr,CPF_q19_corr,Response correct for trial 19,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000020_RESP,CPF_q20_resp,CPF_q20_resp,Response for trial 20,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000020_TTR,CPF_q20_ttr,CPF_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000020_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000020_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000020_CORR,CPF_q20_corr,CPF_q20_corr,Response correct for trial 20,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000021_RESP,CPF_q21_resp,CPF_q21_resp,Response for trial 21,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000021_TTR,CPF_q21_ttr,CPF_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000021_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000021_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000021_CORR,CPF_q21_corr,CPF_q21_corr,Response correct for trial 21,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000022_RESP,CPF_q22_resp,CPF_q22_resp,Response for trial 22,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000022_TTR,CPF_q22_ttr,CPF_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000022_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000022_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000022_CORR,CPF_q22_corr,CPF_q22_corr,Response correct for trial 22,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000023_RESP,CPF_q23_resp,CPF_q23_resp,Response for trial 23,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000023_TTR,CPF_q23_ttr,CPF_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000023_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000023_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000023_CORR,CPF_q23_corr,CPF_q23_corr,Response correct for trial 23,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000024_RESP,CPF_q24_resp,CPF_q24_resp,Response for trial 24,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000024_TTR,CPF_q24_ttr,CPF_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000024_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000024_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000024_CORR,CPF_q24_corr,CPF_q24_corr,Response correct for trial 24,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000025_RESP,CPF_q25_resp,CPF_q25_resp,Response for trial 25,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000025_TTR,CPF_q25_ttr,CPF_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000025_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000025_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000025_CORR,CPF_q25_corr,CPF_q25_corr,Response correct for trial 25,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000026_RESP,CPF_q26_resp,CPF_q26_resp,Response for trial 26,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000026_TTR,CPF_q26_ttr,CPF_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000026_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000026_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000026_CORR,CPF_q26_corr,CPF_q26_corr,Response correct for trial 26,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000027_RESP,CPF_q27_resp,CPF_q27_resp,Response for trial 27,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000027_TTR,CPF_q27_ttr,CPF_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000027_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000027_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000027_CORR,CPF_q27_corr,CPF_q27_corr,Response correct for trial 27,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000028_RESP,CPF_q28_resp,CPF_q28_resp,Response for trial 28,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000028_TTR,CPF_q28_ttr,CPF_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000028_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000028_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000028_CORR,CPF_q28_corr,CPF_q28_corr,Response correct for trial 28,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000029_RESP,CPF_q29_resp,CPF_q29_resp,Response for trial 29,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000029_TTR,CPF_q29_ttr,CPF_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000029_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000029_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000029_CORR,CPF_q29_corr,CPF_q29_corr,Response correct for trial 29,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000030_RESP,CPF_q30_resp,CPF_q30_resp,Response for trial 30,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000030_TTR,CPF_q30_ttr,CPF_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000030_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000030_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000030_CORR,CPF_q30_corr,CPF_q30_corr,Response correct for trial 30,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000031_RESP,CPF_q31_resp,CPF_q31_resp,Response for trial 31,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000031_TTR,CPF_q31_ttr,CPF_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000031_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000031_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000031_CORR,CPF_q31_corr,CPF_q31_corr,Response correct for trial 31,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000032_RESP,CPF_q32_resp,CPF_q32_resp,Response for trial 32,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000032_TTR,CPF_q32_ttr,CPF_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000032_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000032_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000032_CORR,CPF_q32_corr,CPF_q32_corr,Response correct for trial 32,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000033_RESP,CPF_q33_resp,CPF_q33_resp,Response for trial 33,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000033_TTR,CPF_q33_ttr,CPF_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000033_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000033_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000033_CORR,CPF_q33_corr,CPF_q33_corr,Response correct for trial 33,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000034_RESP,CPF_q34_resp,CPF_q34_resp,Response for trial 34,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000034_TTR,CPF_q34_ttr,CPF_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000034_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000034_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000034_CORR,CPF_q34_corr,CPF_q34_corr,Response correct for trial 34,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000035_RESP,CPF_q35_resp,CPF_q35_resp,Response for trial 35,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000035_TTR,CPF_q35_ttr,CPF_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000035_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000035_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000035_CORR,CPF_q35_corr,CPF_q35_corr,Response correct for trial 35,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000036_RESP,CPF_q36_resp,CPF_q36_resp,Response for trial 36,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000036_TTR,CPF_q36_ttr,CPF_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000036_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000036_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000036_CORR,CPF_q36_corr,CPF_q36_corr,Response correct for trial 36,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000037_RESP,CPF_q37_resp,CPF_q37_resp,Response for trial 37,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000037_TTR,CPF_q37_ttr,CPF_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000037_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000037_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000037_CORR,CPF_q37_corr,CPF_q37_corr,Response correct for trial 37,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000038_RESP,CPF_q38_resp,CPF_q38_resp,Response for trial 38,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000038_TTR,CPF_q38_ttr,CPF_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000038_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000038_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000038_CORR,CPF_q38_corr,CPF_q38_corr,Response correct for trial 38,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000039_RESP,CPF_q39_resp,CPF_q39_resp,Response for trial 39,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000039_TTR,CPF_q39_ttr,CPF_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000039_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000039_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000039_CORR,CPF_q39_corr,CPF_q39_corr,Response correct for trial 39,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000040_RESP,CPF_q40_resp,CPF_q40_resp,Response for trial 40,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000040_TTR,CPF_q40_ttr,CPF_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000040_TRIAL,,,Trial Order of Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000040_QID,,,Question ID for Stimuli Presented,Penn Facial Memory Test
+CPF_A_CPF_TRIAL000040_CORR,CPF_q40_corr,CPF_q40_corr,Response correct for trial 40,Penn Facial Memory Test
+CPFD_A_ScorVers,CPFD_A_ScorVers,CPFD,Current Programming Version of the Scoring Code,Penn Facial Memory Test - Delayed Version
+CPFD_A_status,CPFD_A_status,CPFD_status,Status Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
+CPFD_A_valid_code,CPFD_A_valid_code,CPFD_valid_code,Valid Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TP,CPFD_A_CPFD_TP,CPFD_CPFDTP,CPFD True Positives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TN,CPFD_A_CPFD_TN,CPFD_CPFDTN,CPFD True Negatives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FP,CPFD_A_CPFD_FP,CPFD_CPFDFP,CPFD False Positives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FN,CPFD_A_CPFD_FN,CPFD_CPFDFN,CPFD False Negatives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TPRT,CPFD_A_CPFD_TPRT,CPFD_CPFDTPRT,CPFD True Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TNRT,CPFD_A_CPFD_TNRT,CPFD_CPFDTNRT,CPFD True Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FPRT,CPFD_A_CPFD_FPRT,CPFD_CPFDFPRT,CPFD False Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FNRT,CPFD_A_CPFD_FNRT,CPFD_CPFDFNRT,CPFD False Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_CR,CPFD_A_CPFD_CR,CPFD_DFAC_TOT,CPFD Total Correct Responses,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RTCR,CPFD_A_CPFD_RTCR,CPFD_DFAC_RTC,CPFD Median Total Correct Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_W_RTCR,CPFD_A_CPFD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_ER,CPFD_A_CPFD_ER,,Total Incorrect Responses,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RTER,CPFD_A_CPFD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_W_RTER,CPFD_A_CPFD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RT,CPFD_A_CPFD_RT,,Median Response Time for All Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_RESP,CPFD_A_CPFD_TRIAL000001_RESP,CPFD_q1_resp,Response for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_TTR,CPFD_A_CPFD_TRIAL000001_TTR,CPFD_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_TRIAL,CPFD_A_CPFD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_QID,CPFD_A_CPFD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_CORR,CPFD_A_CPFD_TRIAL000001_CORR,CPFD_q1_corr,Response correct for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_RESP,CPFD_A_CPFD_TRIAL000002_RESP,CPFD_q2_resp,Response for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_TTR,CPFD_A_CPFD_TRIAL000002_TTR,CPFD_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_TRIAL,CPFD_A_CPFD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_QID,CPFD_A_CPFD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_CORR,CPFD_A_CPFD_TRIAL000002_CORR,CPFD_q2_corr,Response correct for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_RESP,CPFD_A_CPFD_TRIAL000003_RESP,CPFD_q3_resp,Response for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_TTR,CPFD_A_CPFD_TRIAL000003_TTR,CPFD_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_TRIAL,CPFD_A_CPFD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_QID,CPFD_A_CPFD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_CORR,CPFD_A_CPFD_TRIAL000003_CORR,CPFD_q3_corr,Response correct for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_RESP,CPFD_A_CPFD_TRIAL000004_RESP,CPFD_q4_resp,Response for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_TTR,CPFD_A_CPFD_TRIAL000004_TTR,CPFD_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_TRIAL,CPFD_A_CPFD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_QID,CPFD_A_CPFD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_CORR,CPFD_A_CPFD_TRIAL000004_CORR,CPFD_q4_corr,Response correct for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_RESP,CPFD_A_CPFD_TRIAL000005_RESP,CPFD_q5_resp,Response for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_TTR,CPFD_A_CPFD_TRIAL000005_TTR,CPFD_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_TRIAL,CPFD_A_CPFD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_QID,CPFD_A_CPFD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_CORR,CPFD_A_CPFD_TRIAL000005_CORR,CPFD_q5_corr,Response correct for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_RESP,CPFD_A_CPFD_TRIAL000006_RESP,CPFD_q6_resp,Response for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_TTR,CPFD_A_CPFD_TRIAL000006_TTR,CPFD_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_TRIAL,CPFD_A_CPFD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_QID,CPFD_A_CPFD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_CORR,CPFD_A_CPFD_TRIAL000006_CORR,CPFD_q6_corr,Response correct for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_RESP,CPFD_A_CPFD_TRIAL000007_RESP,CPFD_q7_resp,Response for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_TTR,CPFD_A_CPFD_TRIAL000007_TTR,CPFD_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_TRIAL,CPFD_A_CPFD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_QID,CPFD_A_CPFD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_CORR,CPFD_A_CPFD_TRIAL000007_CORR,CPFD_q7_corr,Response correct for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_RESP,CPFD_A_CPFD_TRIAL000008_RESP,CPFD_q8_resp,Response for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_TTR,CPFD_A_CPFD_TRIAL000008_TTR,CPFD_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_TRIAL,CPFD_A_CPFD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_QID,CPFD_A_CPFD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_CORR,CPFD_A_CPFD_TRIAL000008_CORR,CPFD_q8_corr,Response correct for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_RESP,CPFD_A_CPFD_TRIAL000009_RESP,CPFD_q9_resp,Response for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_TTR,CPFD_A_CPFD_TRIAL000009_TTR,CPFD_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_TRIAL,CPFD_A_CPFD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_QID,CPFD_A_CPFD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_CORR,CPFD_A_CPFD_TRIAL000009_CORR,CPFD_q9_corr,Response correct for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_RESP,CPFD_A_CPFD_TRIAL000010_RESP,CPFD_q10_resp,Response for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_TTR,CPFD_A_CPFD_TRIAL000010_TTR,CPFD_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_TRIAL,CPFD_A_CPFD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_QID,CPFD_A_CPFD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_CORR,CPFD_A_CPFD_TRIAL000010_CORR,CPFD_q10_corr,Response correct for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_RESP,CPFD_A_CPFD_TRIAL000011_RESP,CPFD_q11_resp,Response for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_TTR,CPFD_A_CPFD_TRIAL000011_TTR,CPFD_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_TRIAL,CPFD_A_CPFD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_QID,CPFD_A_CPFD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_CORR,CPFD_A_CPFD_TRIAL000011_CORR,CPFD_q11_corr,Response correct for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_RESP,CPFD_A_CPFD_TRIAL000012_RESP,CPFD_q12_resp,Response for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_TTR,CPFD_A_CPFD_TRIAL000012_TTR,CPFD_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_TRIAL,CPFD_A_CPFD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_QID,CPFD_A_CPFD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_CORR,CPFD_A_CPFD_TRIAL000012_CORR,CPFD_q12_corr,Response correct for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_RESP,CPFD_A_CPFD_TRIAL000013_RESP,CPFD_q13_resp,Response for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_TTR,CPFD_A_CPFD_TRIAL000013_TTR,CPFD_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_TRIAL,CPFD_A_CPFD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_QID,CPFD_A_CPFD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_CORR,CPFD_A_CPFD_TRIAL000013_CORR,CPFD_q13_corr,Response correct for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_RESP,CPFD_A_CPFD_TRIAL000014_RESP,CPFD_q14_resp,Response for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_TTR,CPFD_A_CPFD_TRIAL000014_TTR,CPFD_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_TRIAL,CPFD_A_CPFD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_QID,CPFD_A_CPFD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_CORR,CPFD_A_CPFD_TRIAL000014_CORR,CPFD_q14_corr,Response correct for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_RESP,CPFD_A_CPFD_TRIAL000015_RESP,CPFD_q15_resp,Response for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_TTR,CPFD_A_CPFD_TRIAL000015_TTR,CPFD_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_TRIAL,CPFD_A_CPFD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_QID,CPFD_A_CPFD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_CORR,CPFD_A_CPFD_TRIAL000015_CORR,CPFD_q15_corr,Response correct for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_RESP,CPFD_A_CPFD_TRIAL000016_RESP,CPFD_q16_resp,Response for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_TTR,CPFD_A_CPFD_TRIAL000016_TTR,CPFD_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_TRIAL,CPFD_A_CPFD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_QID,CPFD_A_CPFD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_CORR,CPFD_A_CPFD_TRIAL000016_CORR,CPFD_q16_corr,Response correct for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_RESP,CPFD_A_CPFD_TRIAL000017_RESP,CPFD_q17_resp,Response for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_TTR,CPFD_A_CPFD_TRIAL000017_TTR,CPFD_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_TRIAL,CPFD_A_CPFD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_QID,CPFD_A_CPFD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_CORR,CPFD_A_CPFD_TRIAL000017_CORR,CPFD_q17_corr,Response correct for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_RESP,CPFD_A_CPFD_TRIAL000018_RESP,CPFD_q18_resp,Response for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_TTR,CPFD_A_CPFD_TRIAL000018_TTR,CPFD_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_TRIAL,CPFD_A_CPFD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_QID,CPFD_A_CPFD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_CORR,CPFD_A_CPFD_TRIAL000018_CORR,CPFD_q18_corr,Response correct for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_RESP,CPFD_A_CPFD_TRIAL000019_RESP,CPFD_q19_resp,Response for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_TTR,CPFD_A_CPFD_TRIAL000019_TTR,CPFD_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_TRIAL,CPFD_A_CPFD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_QID,CPFD_A_CPFD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_CORR,CPFD_A_CPFD_TRIAL000019_CORR,CPFD_q19_corr,Response correct for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_RESP,CPFD_A_CPFD_TRIAL000020_RESP,CPFD_q20_resp,Response for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_TTR,CPFD_A_CPFD_TRIAL000020_TTR,CPFD_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_TRIAL,CPFD_A_CPFD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_QID,CPFD_A_CPFD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_CORR,CPFD_A_CPFD_TRIAL000020_CORR,CPFD_q20_corr,Response correct for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_RESP,CPFD_A_CPFD_TRIAL000021_RESP,CPFD_q21_resp,Response for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_TTR,CPFD_A_CPFD_TRIAL000021_TTR,CPFD_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_TRIAL,CPFD_A_CPFD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_QID,CPFD_A_CPFD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_CORR,CPFD_A_CPFD_TRIAL000021_CORR,CPFD_q21_corr,Response correct for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_RESP,CPFD_A_CPFD_TRIAL000022_RESP,CPFD_q22_resp,Response for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_TTR,CPFD_A_CPFD_TRIAL000022_TTR,CPFD_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_TRIAL,CPFD_A_CPFD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_QID,CPFD_A_CPFD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_CORR,CPFD_A_CPFD_TRIAL000022_CORR,CPFD_q22_corr,Response correct for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_RESP,CPFD_A_CPFD_TRIAL000023_RESP,CPFD_q23_resp,Response for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_TTR,CPFD_A_CPFD_TRIAL000023_TTR,CPFD_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_TRIAL,CPFD_A_CPFD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_QID,CPFD_A_CPFD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_CORR,CPFD_A_CPFD_TRIAL000023_CORR,CPFD_q23_corr,Response correct for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_RESP,CPFD_A_CPFD_TRIAL000024_RESP,CPFD_q24_resp,Response for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_TTR,CPFD_A_CPFD_TRIAL000024_TTR,CPFD_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_TRIAL,CPFD_A_CPFD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_QID,CPFD_A_CPFD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_CORR,CPFD_A_CPFD_TRIAL000024_CORR,CPFD_q24_corr,Response correct for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_RESP,CPFD_A_CPFD_TRIAL000025_RESP,CPFD_q25_resp,Response for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_TTR,CPFD_A_CPFD_TRIAL000025_TTR,CPFD_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_TRIAL,CPFD_A_CPFD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_QID,CPFD_A_CPFD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_CORR,CPFD_A_CPFD_TRIAL000025_CORR,CPFD_q25_corr,Response correct for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_RESP,CPFD_A_CPFD_TRIAL000026_RESP,CPFD_q26_resp,Response for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_TTR,CPFD_A_CPFD_TRIAL000026_TTR,CPFD_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_TRIAL,CPFD_A_CPFD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_QID,CPFD_A_CPFD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_CORR,CPFD_A_CPFD_TRIAL000026_CORR,CPFD_q26_corr,Response correct for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_RESP,CPFD_A_CPFD_TRIAL000027_RESP,CPFD_q27_resp,Response for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_TTR,CPFD_A_CPFD_TRIAL000027_TTR,CPFD_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_TRIAL,CPFD_A_CPFD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_QID,CPFD_A_CPFD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_CORR,CPFD_A_CPFD_TRIAL000027_CORR,CPFD_q27_corr,Response correct for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_RESP,CPFD_A_CPFD_TRIAL000028_RESP,CPFD_q28_resp,Response for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_TTR,CPFD_A_CPFD_TRIAL000028_TTR,CPFD_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_TRIAL,CPFD_A_CPFD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_QID,CPFD_A_CPFD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_CORR,CPFD_A_CPFD_TRIAL000028_CORR,CPFD_q28_corr,Response correct for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_RESP,CPFD_A_CPFD_TRIAL000029_RESP,CPFD_q29_resp,Response for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_TTR,CPFD_A_CPFD_TRIAL000029_TTR,CPFD_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_TRIAL,CPFD_A_CPFD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_QID,CPFD_A_CPFD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_CORR,CPFD_A_CPFD_TRIAL000029_CORR,CPFD_q29_corr,Response correct for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_RESP,CPFD_A_CPFD_TRIAL000030_RESP,CPFD_q30_resp,Response for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_TTR,CPFD_A_CPFD_TRIAL000030_TTR,CPFD_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_TRIAL,CPFD_A_CPFD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_QID,CPFD_A_CPFD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_CORR,CPFD_A_CPFD_TRIAL000030_CORR,CPFD_q30_corr,Response correct for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_RESP,CPFD_A_CPFD_TRIAL000031_RESP,CPFD_q31_resp,Response for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_TTR,CPFD_A_CPFD_TRIAL000031_TTR,CPFD_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_TRIAL,CPFD_A_CPFD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_QID,CPFD_A_CPFD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_CORR,CPFD_A_CPFD_TRIAL000031_CORR,CPFD_q31_corr,Response correct for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_RESP,CPFD_A_CPFD_TRIAL000032_RESP,CPFD_q32_resp,Response for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_TTR,CPFD_A_CPFD_TRIAL000032_TTR,CPFD_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_TRIAL,CPFD_A_CPFD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_QID,CPFD_A_CPFD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_CORR,CPFD_A_CPFD_TRIAL000032_CORR,CPFD_q32_corr,Response correct for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_RESP,CPFD_A_CPFD_TRIAL000033_RESP,CPFD_q33_resp,Response for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_TTR,CPFD_A_CPFD_TRIAL000033_TTR,CPFD_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_TRIAL,CPFD_A_CPFD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_QID,CPFD_A_CPFD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_CORR,CPFD_A_CPFD_TRIAL000033_CORR,CPFD_q33_corr,Response correct for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_RESP,CPFD_A_CPFD_TRIAL000034_RESP,CPFD_q34_resp,Response for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_TTR,CPFD_A_CPFD_TRIAL000034_TTR,CPFD_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_TRIAL,CPFD_A_CPFD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_QID,CPFD_A_CPFD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_CORR,CPFD_A_CPFD_TRIAL000034_CORR,CPFD_q34_corr,Response correct for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_RESP,CPFD_A_CPFD_TRIAL000035_RESP,CPFD_q35_resp,Response for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_TTR,CPFD_A_CPFD_TRIAL000035_TTR,CPFD_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_TRIAL,CPFD_A_CPFD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_QID,CPFD_A_CPFD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_CORR,CPFD_A_CPFD_TRIAL000035_CORR,CPFD_q35_corr,Response correct for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_RESP,CPFD_A_CPFD_TRIAL000036_RESP,CPFD_q36_resp,Response for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_TTR,CPFD_A_CPFD_TRIAL000036_TTR,CPFD_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_TRIAL,CPFD_A_CPFD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_QID,CPFD_A_CPFD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_CORR,CPFD_A_CPFD_TRIAL000036_CORR,CPFD_q36_corr,Response correct for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_RESP,CPFD_A_CPFD_TRIAL000037_RESP,CPFD_q37_resp,Response for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_TTR,CPFD_A_CPFD_TRIAL000037_TTR,CPFD_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_TRIAL,CPFD_A_CPFD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_QID,CPFD_A_CPFD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_CORR,CPFD_A_CPFD_TRIAL000037_CORR,CPFD_q37_corr,Response correct for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_RESP,CPFD_A_CPFD_TRIAL000038_RESP,CPFD_q38_resp,Response for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_TTR,CPFD_A_CPFD_TRIAL000038_TTR,CPFD_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_TRIAL,CPFD_A_CPFD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_QID,CPFD_A_CPFD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_CORR,CPFD_A_CPFD_TRIAL000038_CORR,CPFD_q38_corr,Response correct for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_RESP,CPFD_A_CPFD_TRIAL000039_RESP,CPFD_q39_resp,Response for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_TTR,CPFD_A_CPFD_TRIAL000039_TTR,CPFD_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_TRIAL,CPFD_A_CPFD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_QID,CPFD_A_CPFD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_CORR,CPFD_A_CPFD_TRIAL000039_CORR,CPFD_q39_corr,Response correct for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_RESP,CPFD_A_CPFD_TRIAL000040_RESP,CPFD_q40_resp,Response for trial 40,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_TTR,CPFD_A_CPFD_TRIAL000040_TTR,CPFD_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_TRIAL,CPFD_A_CPFD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_QID,CPFD_A_CPFD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_CORR,CPFD_A_CPFD_TRIAL000040_CORR,CPFD_q40_corr,Response correct for trial 40,Penn Facial Memory Test - Delayed Version
+CPW_A_ScorVers,CPW_ScorVers,CPW,Current Programming Version of the Scoring Code,Penn Word Memory Test
+CPW_A_status,CPW_status,CPW_status,Status Code Assigned to CPW,Penn Word Memory Test
+CPW_A_valid_code,CPW_valid_code,CPW_valid_code,Valid Code Assigned to CPW,Penn Word Memory Test
+CPW_A_CPW_TP,CPW_CPWTP,CPW_CPWTP,CPW True Positive Responses,Penn Word Memory Test
+CPW_A_CPW_TN,CPW_CPWTN,CPW_CPWTN,CPW True Negative Responses,Penn Word Memory Test
+CPW_A_CPW_FP,CPW_CPWFP,CPW_CPWFP,CPW False Positive Responses,Penn Word Memory Test
+CPW_A_CPW_FN,CPW_CPWFN,CPW_CPWFN,CPW False Negative Responses,Penn Word Memory Test
+CPW_A_CPW_TPRT,CPW_CPWTPRT,CPW_CPWTPRT,Median Response Time for CPW True Positive Responses (ms),Penn Word Memory Test
+CPW_A_CPW_TNRT,CPW_CPWTNRT,CPW_CPWTNRT,Median Response Time for CPW True Negative Responses (ms),Penn Word Memory Test
+CPW_A_CPW_FPRT,CPW_CPWFPRT,CPW_CPWFPRT,Median Response Time for CPW False Positive Responses (ms),Penn Word Memory Test
+CPW_A_CPW_FNRT,CPW_CPWFNRT,CPW_CPWFNRT,Median Response Time for CPW False Negative Responses (ms),Penn Word Memory Test
+CPW_A_CPW_CR,CPW_IWRD_TOT,CPW_IWRD_TOT,CPW Total Correct Responses,Penn Word Memory Test
+CPW_A_CPW_W_RTCR,CPW_IWRD_RTC,CPW_IWRD_RTC,Median Response Time for CPW Total Correct Responses (ms),Penn Word Memory Test
+CPW_A_CPW_RTCR,,,Median Response Time for All Responses (ms),Penn Word Memory Test
+CPW_A_CPW_ER,,,Total Incorrect Responses,Penn Word Memory Test
+CPW_A_CPW_RTER,,,Median Response Time for Incorrect Responses (ms),Penn Word Memory Test
+CPW_A_CPW_W_RTER,,,Weighted Median Response Time for Incorrect Responses (ms),Penn Word Memory Test
+CPW_A_CPW_RT,,,Median Response Time for All Responses (ms),Penn Word Memory Test
+CPW_A_CPW_DY,,,Total Definitely Yes Responses,Penn Word Memory Test
+CPW_A_CPW_DN,,,Total Definitely No Responses,Penn Word Memory Test
+CPW_A_CPW_PY,,,Total Probably Yes Responses,Penn Word Memory Test
+CPW_A_CPW_PN,,,Total Probably No Responses,Penn Word Memory Test
+CPW_A_CPW_DTP,,,Total Definitely True Positive Responses,Penn Word Memory Test
+CPW_A_CPW_PTP,,,Total Probably True Positive Responses,Penn Word Memory Test
+CPW_A_CPW_DTN,,,Total Definitely True Negative Responses,Penn Word Memory Test
+CPW_A_CPW_PTN,,,Total Probably True Negative Responses,Penn Word Memory Test
+CPW_A_CPW_DFP,,,Total Definitely False Positive Responses,Penn Word Memory Test
+CPW_A_CPW_PFP,,,Total Probably False Positive Responses,Penn Word Memory Test
+CPW_A_CPW_DFN,,,Total Definitely False Negative Responses,Penn Word Memory Test
+CPW_A_CPW_PFN,,,Total Probably False Negative Responses,Penn Word Memory Test
+CPW_A_CPW_EFF,,,CPW_A VOLT Efficiency ,Penn Word Memory Test
+CPW_A_CPW_TRIAL000001_RESP,CPW_q1_resp,CPW_q1_resp,Response for trial 1,Penn Word Memory Test
+CPW_A_CPW_TRIAL000001_TTR,CPW_q1_ttr,CPW_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test
+CPW_A_CPW_TRIAL000001_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000001_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000001_CORR,CPW_q1_corr,CPW_q1_corr,Response correct for trial 1,Penn Word Memory Test
+CPW_A_CPW_TRIAL000002_RESP,CPW_q2_resp,CPW_q2_resp,Response for trial 2,Penn Word Memory Test
+CPW_A_CPW_TRIAL000002_TTR,CPW_q2_ttr,CPW_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test
+CPW_A_CPW_TRIAL000002_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000002_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000002_CORR,CPW_q2_corr,CPW_q2_corr,Response correct for trial 2,Penn Word Memory Test
+CPW_A_CPW_TRIAL000003_RESP,CPW_q3_resp,CPW_q3_resp,Response for trial 3,Penn Word Memory Test
+CPW_A_CPW_TRIAL000003_TTR,CPW_q3_ttr,CPW_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test
+CPW_A_CPW_TRIAL000003_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000003_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000003_CORR,CPW_q3_corr,CPW_q3_corr,Response correct for trial 3,Penn Word Memory Test
+CPW_A_CPW_TRIAL000004_RESP,CPW_q4_resp,CPW_q4_resp,Response for trial 4,Penn Word Memory Test
+CPW_A_CPW_TRIAL000004_TTR,CPW_q4_ttr,CPW_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test
+CPW_A_CPW_TRIAL000004_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000004_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000004_CORR,CPW_q4_corr,CPW_q4_corr,Response correct for trial 4,Penn Word Memory Test
+CPW_A_CPW_TRIAL000005_RESP,CPW_q5_resp,CPW_q5_resp,Response for trial 5,Penn Word Memory Test
+CPW_A_CPW_TRIAL000005_TTR,CPW_q5_ttr,CPW_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test
+CPW_A_CPW_TRIAL000005_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000005_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000005_CORR,CPW_q5_corr,CPW_q5_corr,Response correct for trial 5,Penn Word Memory Test
+CPW_A_CPW_TRIAL000006_RESP,CPW_q6_resp,CPW_q6_resp,Response for trial 6,Penn Word Memory Test
+CPW_A_CPW_TRIAL000006_TTR,CPW_q6_ttr,CPW_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test
+CPW_A_CPW_TRIAL000006_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000006_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000006_CORR,CPW_q6_corr,CPW_q6_corr,Response correct for trial 6,Penn Word Memory Test
+CPW_A_CPW_TRIAL000007_RESP,CPW_q7_resp,CPW_q7_resp,Response for trial 7,Penn Word Memory Test
+CPW_A_CPW_TRIAL000007_TTR,CPW_q7_ttr,CPW_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test
+CPW_A_CPW_TRIAL000007_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000007_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000007_CORR,CPW_q7_corr,CPW_q7_corr,Response correct for trial 7,Penn Word Memory Test
+CPW_A_CPW_TRIAL000008_RESP,CPW_q8_resp,CPW_q8_resp,Response for trial 8,Penn Word Memory Test
+CPW_A_CPW_TRIAL000008_TTR,CPW_q8_ttr,CPW_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test
+CPW_A_CPW_TRIAL000008_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000008_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000008_CORR,CPW_q8_corr,CPW_q8_corr,Response correct for trial 8,Penn Word Memory Test
+CPW_A_CPW_TRIAL000009_RESP,CPW_q9_resp,CPW_q9_resp,Response for trial 9,Penn Word Memory Test
+CPW_A_CPW_TRIAL000009_TTR,CPW_q9_ttr,CPW_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test
+CPW_A_CPW_TRIAL000009_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000009_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000009_CORR,CPW_q9_corr,CPW_q9_corr,Response correct for trial 9,Penn Word Memory Test
+CPW_A_CPW_TRIAL000010_RESP,CPW_q10_resp,CPW_q10_resp,Response for trial 10,Penn Word Memory Test
+CPW_A_CPW_TRIAL000010_TTR,CPW_q10_ttr,CPW_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test
+CPW_A_CPW_TRIAL000010_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000010_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000010_CORR,CPW_q10_corr,CPW_q10_corr,Response correct for trial 10,Penn Word Memory Test
+CPW_A_CPW_TRIAL000011_RESP,CPW_q11_resp,CPW_q11_resp,Response for trial 11,Penn Word Memory Test
+CPW_A_CPW_TRIAL000011_TTR,CPW_q11_ttr,CPW_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test
+CPW_A_CPW_TRIAL000011_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000011_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000011_CORR,CPW_q11_corr,CPW_q11_corr,Response correct for trial 11,Penn Word Memory Test
+CPW_A_CPW_TRIAL000012_RESP,CPW_q12_resp,CPW_q12_resp,Response for trial 12,Penn Word Memory Test
+CPW_A_CPW_TRIAL000012_TTR,CPW_q12_ttr,CPW_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test
+CPW_A_CPW_TRIAL000012_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000012_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000012_CORR,CPW_q12_corr,CPW_q12_corr,Response correct for trial 12,Penn Word Memory Test
+CPW_A_CPW_TRIAL000013_RESP,CPW_q13_resp,CPW_q13_resp,Response for trial 13,Penn Word Memory Test
+CPW_A_CPW_TRIAL000013_TTR,CPW_q13_ttr,CPW_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test
+CPW_A_CPW_TRIAL000013_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000013_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000013_CORR,CPW_q13_corr,CPW_q13_corr,Response correct for trial 13,Penn Word Memory Test
+CPW_A_CPW_TRIAL000014_RESP,CPW_q14_resp,CPW_q14_resp,Response for trial 14,Penn Word Memory Test
+CPW_A_CPW_TRIAL000014_TTR,CPW_q14_ttr,CPW_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test
+CPW_A_CPW_TRIAL000014_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000014_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000014_CORR,CPW_q14_corr,CPW_q14_corr,Response correct for trial 14,Penn Word Memory Test
+CPW_A_CPW_TRIAL000015_RESP,CPW_q15_resp,CPW_q15_resp,Response for trial 15,Penn Word Memory Test
+CPW_A_CPW_TRIAL000015_TTR,CPW_q15_ttr,CPW_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test
+CPW_A_CPW_TRIAL000015_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000015_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000015_CORR,CPW_q15_corr,CPW_q15_corr,Response correct for trial 15,Penn Word Memory Test
+CPW_A_CPW_TRIAL000016_RESP,CPW_q16_resp,CPW_q16_resp,Response for trial 16,Penn Word Memory Test
+CPW_A_CPW_TRIAL000016_TTR,CPW_q16_ttr,CPW_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test
+CPW_A_CPW_TRIAL000016_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000016_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000016_CORR,CPW_q16_corr,CPW_q16_corr,Response correct for trial 16,Penn Word Memory Test
+CPW_A_CPW_TRIAL000017_RESP,CPW_q17_resp,CPW_q17_resp,Response for trial 17,Penn Word Memory Test
+CPW_A_CPW_TRIAL000017_TTR,CPW_q17_ttr,CPW_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test
+CPW_A_CPW_TRIAL000017_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000017_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000017_CORR,CPW_q17_corr,CPW_q17_corr,Response correct for trial 17,Penn Word Memory Test
+CPW_A_CPW_TRIAL000018_RESP,CPW_q18_resp,CPW_q18_resp,Response for trial 18,Penn Word Memory Test
+CPW_A_CPW_TRIAL000018_TTR,CPW_q18_ttr,CPW_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test
+CPW_A_CPW_TRIAL000018_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000018_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000018_CORR,CPW_q18_corr,CPW_q18_corr,Response correct for trial 18,Penn Word Memory Test
+CPW_A_CPW_TRIAL000019_RESP,CPW_q19_resp,CPW_q19_resp,Response for trial 19,Penn Word Memory Test
+CPW_A_CPW_TRIAL000019_TTR,CPW_q19_ttr,CPW_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test
+CPW_A_CPW_TRIAL000019_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000019_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000019_CORR,CPW_q19_corr,CPW_q19_corr,Response correct for trial 19,Penn Word Memory Test
+CPW_A_CPW_TRIAL000020_RESP,CPW_q20_resp,CPW_q20_resp,Response for trial 20,Penn Word Memory Test
+CPW_A_CPW_TRIAL000020_TTR,CPW_q20_ttr,CPW_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test
+CPW_A_CPW_TRIAL000020_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000020_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000020_CORR,CPW_q20_corr,CPW_q20_corr,Response correct for trial 20,Penn Word Memory Test
+CPW_A_CPW_TRIAL000021_RESP,CPW_q21_resp,CPW_q21_resp,Response for trial 21,Penn Word Memory Test
+CPW_A_CPW_TRIAL000021_TTR,CPW_q21_ttr,CPW_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test
+CPW_A_CPW_TRIAL000021_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000021_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000021_CORR,CPW_q21_corr,CPW_q21_corr,Response correct for trial 21,Penn Word Memory Test
+CPW_A_CPW_TRIAL000022_RESP,CPW_q22_resp,CPW_q22_resp,Response for trial 22,Penn Word Memory Test
+CPW_A_CPW_TRIAL000022_TTR,CPW_q22_ttr,CPW_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test
+CPW_A_CPW_TRIAL000022_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000022_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000022_CORR,CPW_q22_corr,CPW_q22_corr,Response correct for trial 22,Penn Word Memory Test
+CPW_A_CPW_TRIAL000023_RESP,CPW_q23_resp,CPW_q23_resp,Response for trial 23,Penn Word Memory Test
+CPW_A_CPW_TRIAL000023_TTR,CPW_q23_ttr,CPW_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test
+CPW_A_CPW_TRIAL000023_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000023_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000023_CORR,CPW_q23_corr,CPW_q23_corr,Response correct for trial 23,Penn Word Memory Test
+CPW_A_CPW_TRIAL000024_RESP,CPW_q24_resp,CPW_q24_resp,Response for trial 24,Penn Word Memory Test
+CPW_A_CPW_TRIAL000024_TTR,CPW_q24_ttr,CPW_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test
+CPW_A_CPW_TRIAL000024_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000024_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000024_CORR,CPW_q24_corr,CPW_q24_corr,Response correct for trial 24,Penn Word Memory Test
+CPW_A_CPW_TRIAL000025_RESP,CPW_q25_resp,CPW_q25_resp,Response for trial 25,Penn Word Memory Test
+CPW_A_CPW_TRIAL000025_TTR,CPW_q25_ttr,CPW_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test
+CPW_A_CPW_TRIAL000025_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000025_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000025_CORR,CPW_q25_corr,CPW_q25_corr,Response correct for trial 25,Penn Word Memory Test
+CPW_A_CPW_TRIAL000026_RESP,CPW_q26_resp,CPW_q26_resp,Response for trial 26,Penn Word Memory Test
+CPW_A_CPW_TRIAL000026_TTR,CPW_q26_ttr,CPW_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test
+CPW_A_CPW_TRIAL000026_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000026_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000026_CORR,CPW_q26_corr,CPW_q26_corr,Response correct for trial 26,Penn Word Memory Test
+CPW_A_CPW_TRIAL000027_RESP,CPW_q27_resp,CPW_q27_resp,Response for trial 27,Penn Word Memory Test
+CPW_A_CPW_TRIAL000027_TTR,CPW_q27_ttr,CPW_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test
+CPW_A_CPW_TRIAL000027_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000027_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000027_CORR,CPW_q27_corr,CPW_q27_corr,Response correct for trial 27,Penn Word Memory Test
+CPW_A_CPW_TRIAL000028_RESP,CPW_q28_resp,CPW_q28_resp,Response for trial 28,Penn Word Memory Test
+CPW_A_CPW_TRIAL000028_TTR,CPW_q28_ttr,CPW_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test
+CPW_A_CPW_TRIAL000028_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000028_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000028_CORR,CPW_q28_corr,CPW_q28_corr,Response correct for trial 28,Penn Word Memory Test
+CPW_A_CPW_TRIAL000029_RESP,CPW_q29_resp,CPW_q29_resp,Response for trial 29,Penn Word Memory Test
+CPW_A_CPW_TRIAL000029_TTR,CPW_q29_ttr,CPW_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test
+CPW_A_CPW_TRIAL000029_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000029_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000029_CORR,CPW_q29_corr,CPW_q29_corr,Response correct for trial 29,Penn Word Memory Test
+CPW_A_CPW_TRIAL000030_RESP,CPW_q30_resp,CPW_q30_resp,Response for trial 30,Penn Word Memory Test
+CPW_A_CPW_TRIAL000030_TTR,CPW_q30_ttr,CPW_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test
+CPW_A_CPW_TRIAL000030_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000030_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000030_CORR,CPW_q30_corr,CPW_q30_corr,Response correct for trial 30,Penn Word Memory Test
+CPW_A_CPW_TRIAL000031_RESP,CPW_q31_resp,CPW_q31_resp,Response for trial 31,Penn Word Memory Test
+CPW_A_CPW_TRIAL000031_TTR,CPW_q31_ttr,CPW_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test
+CPW_A_CPW_TRIAL000031_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000031_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000031_CORR,CPW_q31_corr,CPW_q31_corr,Response correct for trial 31,Penn Word Memory Test
+CPW_A_CPW_TRIAL000032_RESP,CPW_q32_resp,CPW_q32_resp,Response for trial 32,Penn Word Memory Test
+CPW_A_CPW_TRIAL000032_TTR,CPW_q32_ttr,CPW_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test
+CPW_A_CPW_TRIAL000032_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000032_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000032_CORR,CPW_q32_corr,CPW_q32_corr,Response correct for trial 32,Penn Word Memory Test
+CPW_A_CPW_TRIAL000033_RESP,CPW_q33_resp,CPW_q33_resp,Response for trial 33,Penn Word Memory Test
+CPW_A_CPW_TRIAL000033_TTR,CPW_q33_ttr,CPW_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test
+CPW_A_CPW_TRIAL000033_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000033_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000033_CORR,CPW_q33_corr,CPW_q33_corr,Response correct for trial 33,Penn Word Memory Test
+CPW_A_CPW_TRIAL000034_RESP,CPW_q34_resp,CPW_q34_resp,Response for trial 34,Penn Word Memory Test
+CPW_A_CPW_TRIAL000034_TTR,CPW_q34_ttr,CPW_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test
+CPW_A_CPW_TRIAL000034_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000034_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000034_CORR,CPW_q34_corr,CPW_q34_corr,Response correct for trial 34,Penn Word Memory Test
+CPW_A_CPW_TRIAL000035_RESP,CPW_q35_resp,CPW_q35_resp,Response for trial 35,Penn Word Memory Test
+CPW_A_CPW_TRIAL000035_TTR,CPW_q35_ttr,CPW_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test
+CPW_A_CPW_TRIAL000035_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000035_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000035_CORR,CPW_q35_corr,CPW_q35_corr,Response correct for trial 35,Penn Word Memory Test
+CPW_A_CPW_TRIAL000036_RESP,CPW_q36_resp,CPW_q36_resp,Response for trial 36,Penn Word Memory Test
+CPW_A_CPW_TRIAL000036_TTR,CPW_q36_ttr,CPW_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test
+CPW_A_CPW_TRIAL000036_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000036_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000036_CORR,CPW_q36_corr,CPW_q36_corr,Response correct for trial 36,Penn Word Memory Test
+CPW_A_CPW_TRIAL000037_RESP,CPW_q37_resp,CPW_q37_resp,Response for trial 37,Penn Word Memory Test
+CPW_A_CPW_TRIAL000037_TTR,CPW_q37_ttr,CPW_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test
+CPW_A_CPW_TRIAL000037_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000037_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000037_CORR,CPW_q37_corr,CPW_q37_corr,Response correct for trial 37,Penn Word Memory Test
+CPW_A_CPW_TRIAL000038_RESP,CPW_q38_resp,CPW_q38_resp,Response for trial 38,Penn Word Memory Test
+CPW_A_CPW_TRIAL000038_TTR,CPW_q38_ttr,CPW_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test
+CPW_A_CPW_TRIAL000038_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000038_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000038_CORR,CPW_q38_corr,CPW_q38_corr,Response correct for trial 38,Penn Word Memory Test
+CPW_A_CPW_TRIAL000039_RESP,CPW_q39_resp,CPW_q39_resp,Response for trial 39,Penn Word Memory Test
+CPW_A_CPW_TRIAL000039_TTR,CPW_q39_ttr,CPW_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test
+CPW_A_CPW_TRIAL000039_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000039_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000039_CORR,CPW_q39_corr,CPW_q39_corr,Response correct for trial 39,Penn Word Memory Test
+CPW_A_CPW_TRIAL000040_RESP,CPW_q40_resp,CPW_q40_resp,Response for trial 40,Penn Word Memory Test
+CPW_A_CPW_TRIAL000040_TTR,CPW_q40_ttr,CPW_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test
+CPW_A_CPW_TRIAL000040_TRIAL,,,Trial Order of Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000040_QID,,,Question ID for Stimuli Presented,Penn Word Memory Test
+CPW_A_CPW_TRIAL000040_CORR,CPW_q40_corr,CPW_q40_corr,Response correct for trial 40,Penn Word Memory Test
+CPWD_A_ScorVers,CPWD_A_ScorVers,CPWD,Current Programming Version of the Scoring Code,Penn Word Memory Test - Delayed Version
+CPWD_A_status,CPWD_A_status,CPWD_status,Status Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
+CPWD_A_valid_code,CPWD_A_valid_code,CPWD_valid_code,Valid Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TP,CPWD_A_CPWD_TP,CPWD_CPWDTP,CPWD True Positive Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TN,CPWD_A_CPWD_TN,CPWD_CPWDTN,CPWD True Negative Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FP,CPWD_A_CPWD_FP,CPWD_CPWDFP,CPWD False Positive Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FN,CPWD_A_CPWD_FN,CPWD_CPWDFN,CPWD False Negative Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TPRT,CPWD_A_CPWD_TPRT,CPWD_CPWDTPRT,Median Response Time for CPWD True Positive Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TNRT,CPWD_A_CPWD_TNRT,CPWD_CPWDTNRT,Median Response Time for CPWD True Negative Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FPRT,CPWD_A_CPWD_FPRT,CPWD_CPWDFPRT,Median Response Time for CPWD False Positive Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FNRT,CPWD_A_CPWD_FNRT,CPWD_CPWDFNRT,Median Response Time for CPWD False Negative Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_CR,CPWD_A_CPWD_CR,CPWD_DWRD_TOT,CPWD Total Correct Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RTCR,CPWD_A_CPWD_RTCR,CPWD_DWRD_RTC,Median Response Time for CPWD Total Correct Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_W_RTCR,CPWD_A_CPWD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_ER,CPWD_A_CPWD_ER,,Total Incorrect Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RTER,CPWD_A_CPWD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_W_RTER,CPWD_A_CPWD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RT,CPWD_A_CPWD_RT,,Median Response Time for All Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_RESP,CPWD_A_CPWD_TRIAL000001_RESP,CPWD_q1_resp,Response for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_TTR,CPWD_A_CPWD_TRIAL000001_TTR,CPWD_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_TRIAL,CPWD_A_CPWD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_QID,CPWD_A_CPWD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_CORR,CPWD_A_CPWD_TRIAL000001_CORR,CPWD_q1_corr,Response correct for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_RESP,CPWD_A_CPWD_TRIAL000002_RESP,CPWD_q2_resp,Response for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_TTR,CPWD_A_CPWD_TRIAL000002_TTR,CPWD_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_TRIAL,CPWD_A_CPWD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_QID,CPWD_A_CPWD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_CORR,CPWD_A_CPWD_TRIAL000002_CORR,CPWD_q2_corr,Response correct for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_RESP,CPWD_A_CPWD_TRIAL000003_RESP,CPWD_q3_resp,Response for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_TTR,CPWD_A_CPWD_TRIAL000003_TTR,CPWD_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_TRIAL,CPWD_A_CPWD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_QID,CPWD_A_CPWD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_CORR,CPWD_A_CPWD_TRIAL000003_CORR,CPWD_q3_corr,Response correct for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_RESP,CPWD_A_CPWD_TRIAL000004_RESP,CPWD_q4_resp,Response for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_TTR,CPWD_A_CPWD_TRIAL000004_TTR,CPWD_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_TRIAL,CPWD_A_CPWD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_QID,CPWD_A_CPWD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_CORR,CPWD_A_CPWD_TRIAL000004_CORR,CPWD_q4_corr,Response correct for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_RESP,CPWD_A_CPWD_TRIAL000005_RESP,CPWD_q5_resp,Response for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_TTR,CPWD_A_CPWD_TRIAL000005_TTR,CPWD_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_TRIAL,CPWD_A_CPWD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_QID,CPWD_A_CPWD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_CORR,CPWD_A_CPWD_TRIAL000005_CORR,CPWD_q5_corr,Response correct for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_RESP,CPWD_A_CPWD_TRIAL000006_RESP,CPWD_q6_resp,Response for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_TTR,CPWD_A_CPWD_TRIAL000006_TTR,CPWD_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_TRIAL,CPWD_A_CPWD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_QID,CPWD_A_CPWD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_CORR,CPWD_A_CPWD_TRIAL000006_CORR,CPWD_q6_corr,Response correct for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_RESP,CPWD_A_CPWD_TRIAL000007_RESP,CPWD_q7_resp,Response for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_TTR,CPWD_A_CPWD_TRIAL000007_TTR,CPWD_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_TRIAL,CPWD_A_CPWD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_QID,CPWD_A_CPWD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_CORR,CPWD_A_CPWD_TRIAL000007_CORR,CPWD_q7_corr,Response correct for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_RESP,CPWD_A_CPWD_TRIAL000008_RESP,CPWD_q8_resp,Response for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_TTR,CPWD_A_CPWD_TRIAL000008_TTR,CPWD_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_TRIAL,CPWD_A_CPWD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_QID,CPWD_A_CPWD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_CORR,CPWD_A_CPWD_TRIAL000008_CORR,CPWD_q8_corr,Response correct for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_RESP,CPWD_A_CPWD_TRIAL000009_RESP,CPWD_q9_resp,Response for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_TTR,CPWD_A_CPWD_TRIAL000009_TTR,CPWD_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_TRIAL,CPWD_A_CPWD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_QID,CPWD_A_CPWD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_CORR,CPWD_A_CPWD_TRIAL000009_CORR,CPWD_q9_corr,Response correct for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_RESP,CPWD_A_CPWD_TRIAL000010_RESP,CPWD_q10_resp,Response for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_TTR,CPWD_A_CPWD_TRIAL000010_TTR,CPWD_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_TRIAL,CPWD_A_CPWD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_QID,CPWD_A_CPWD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_CORR,CPWD_A_CPWD_TRIAL000010_CORR,CPWD_q10_corr,Response correct for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_RESP,CPWD_A_CPWD_TRIAL000011_RESP,CPWD_q11_resp,Response for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_TTR,CPWD_A_CPWD_TRIAL000011_TTR,CPWD_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_TRIAL,CPWD_A_CPWD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_QID,CPWD_A_CPWD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_CORR,CPWD_A_CPWD_TRIAL000011_CORR,CPWD_q11_corr,Response correct for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_RESP,CPWD_A_CPWD_TRIAL000012_RESP,CPWD_q12_resp,Response for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_TTR,CPWD_A_CPWD_TRIAL000012_TTR,CPWD_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_TRIAL,CPWD_A_CPWD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_QID,CPWD_A_CPWD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_CORR,CPWD_A_CPWD_TRIAL000012_CORR,CPWD_q12_corr,Response correct for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_RESP,CPWD_A_CPWD_TRIAL000013_RESP,CPWD_q13_resp,Response for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_TTR,CPWD_A_CPWD_TRIAL000013_TTR,CPWD_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_TRIAL,CPWD_A_CPWD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_QID,CPWD_A_CPWD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_CORR,CPWD_A_CPWD_TRIAL000013_CORR,CPWD_q13_corr,Response correct for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_RESP,CPWD_A_CPWD_TRIAL000014_RESP,CPWD_q14_resp,Response for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_TTR,CPWD_A_CPWD_TRIAL000014_TTR,CPWD_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_TRIAL,CPWD_A_CPWD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_QID,CPWD_A_CPWD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_CORR,CPWD_A_CPWD_TRIAL000014_CORR,CPWD_q14_corr,Response correct for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_RESP,CPWD_A_CPWD_TRIAL000015_RESP,CPWD_q15_resp,Response for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_TTR,CPWD_A_CPWD_TRIAL000015_TTR,CPWD_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_TRIAL,CPWD_A_CPWD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_QID,CPWD_A_CPWD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_CORR,CPWD_A_CPWD_TRIAL000015_CORR,CPWD_q15_corr,Response correct for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_RESP,CPWD_A_CPWD_TRIAL000016_RESP,CPWD_q16_resp,Response for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_TTR,CPWD_A_CPWD_TRIAL000016_TTR,CPWD_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_TRIAL,CPWD_A_CPWD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_QID,CPWD_A_CPWD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_CORR,CPWD_A_CPWD_TRIAL000016_CORR,CPWD_q16_corr,Response correct for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_RESP,CPWD_A_CPWD_TRIAL000017_RESP,CPWD_q17_resp,Response for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_TTR,CPWD_A_CPWD_TRIAL000017_TTR,CPWD_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_TRIAL,CPWD_A_CPWD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_QID,CPWD_A_CPWD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_CORR,CPWD_A_CPWD_TRIAL000017_CORR,CPWD_q17_corr,Response correct for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_RESP,CPWD_A_CPWD_TRIAL000018_RESP,CPWD_q18_resp,Response for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_TTR,CPWD_A_CPWD_TRIAL000018_TTR,CPWD_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_TRIAL,CPWD_A_CPWD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_QID,CPWD_A_CPWD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_CORR,CPWD_A_CPWD_TRIAL000018_CORR,CPWD_q18_corr,Response correct for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_RESP,CPWD_A_CPWD_TRIAL000019_RESP,CPWD_q19_resp,Response for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_TTR,CPWD_A_CPWD_TRIAL000019_TTR,CPWD_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_TRIAL,CPWD_A_CPWD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_QID,CPWD_A_CPWD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_CORR,CPWD_A_CPWD_TRIAL000019_CORR,CPWD_q19_corr,Response correct for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_RESP,CPWD_A_CPWD_TRIAL000020_RESP,CPWD_q20_resp,Response for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_TTR,CPWD_A_CPWD_TRIAL000020_TTR,CPWD_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_TRIAL,CPWD_A_CPWD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_QID,CPWD_A_CPWD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_CORR,CPWD_A_CPWD_TRIAL000020_CORR,CPWD_q20_corr,Response correct for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_RESP,CPWD_A_CPWD_TRIAL000021_RESP,CPWD_q21_resp,Response for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_TTR,CPWD_A_CPWD_TRIAL000021_TTR,CPWD_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_TRIAL,CPWD_A_CPWD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_QID,CPWD_A_CPWD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_CORR,CPWD_A_CPWD_TRIAL000021_CORR,CPWD_q21_corr,Response correct for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_RESP,CPWD_A_CPWD_TRIAL000022_RESP,CPWD_q22_resp,Response for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_TTR,CPWD_A_CPWD_TRIAL000022_TTR,CPWD_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_TRIAL,CPWD_A_CPWD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_QID,CPWD_A_CPWD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_CORR,CPWD_A_CPWD_TRIAL000022_CORR,CPWD_q22_corr,Response correct for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_RESP,CPWD_A_CPWD_TRIAL000023_RESP,CPWD_q23_resp,Response for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_TTR,CPWD_A_CPWD_TRIAL000023_TTR,CPWD_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_TRIAL,CPWD_A_CPWD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_QID,CPWD_A_CPWD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_CORR,CPWD_A_CPWD_TRIAL000023_CORR,CPWD_q23_corr,Response correct for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_RESP,CPWD_A_CPWD_TRIAL000024_RESP,CPWD_q24_resp,Response for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_TTR,CPWD_A_CPWD_TRIAL000024_TTR,CPWD_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_TRIAL,CPWD_A_CPWD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_QID,CPWD_A_CPWD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_CORR,CPWD_A_CPWD_TRIAL000024_CORR,CPWD_q24_corr,Response correct for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_RESP,CPWD_A_CPWD_TRIAL000025_RESP,CPWD_q25_resp,Response for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_TTR,CPWD_A_CPWD_TRIAL000025_TTR,CPWD_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_TRIAL,CPWD_A_CPWD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_QID,CPWD_A_CPWD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_CORR,CPWD_A_CPWD_TRIAL000025_CORR,CPWD_q25_corr,Response correct for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_RESP,CPWD_A_CPWD_TRIAL000026_RESP,CPWD_q26_resp,Response for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_TTR,CPWD_A_CPWD_TRIAL000026_TTR,CPWD_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_TRIAL,CPWD_A_CPWD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_QID,CPWD_A_CPWD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_CORR,CPWD_A_CPWD_TRIAL000026_CORR,CPWD_q26_corr,Response correct for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_RESP,CPWD_A_CPWD_TRIAL000027_RESP,CPWD_q27_resp,Response for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_TTR,CPWD_A_CPWD_TRIAL000027_TTR,CPWD_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_TRIAL,CPWD_A_CPWD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_QID,CPWD_A_CPWD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_CORR,CPWD_A_CPWD_TRIAL000027_CORR,CPWD_q27_corr,Response correct for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_RESP,CPWD_A_CPWD_TRIAL000028_RESP,CPWD_q28_resp,Response for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_TTR,CPWD_A_CPWD_TRIAL000028_TTR,CPWD_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_TRIAL,CPWD_A_CPWD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_QID,CPWD_A_CPWD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_CORR,CPWD_A_CPWD_TRIAL000028_CORR,CPWD_q28_corr,Response correct for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_RESP,CPWD_A_CPWD_TRIAL000029_RESP,CPWD_q29_resp,Response for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_TTR,CPWD_A_CPWD_TRIAL000029_TTR,CPWD_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_TRIAL,CPWD_A_CPWD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_QID,CPWD_A_CPWD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_CORR,CPWD_A_CPWD_TRIAL000029_CORR,CPWD_q29_corr,Response correct for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_RESP,CPWD_A_CPWD_TRIAL000030_RESP,CPWD_q30_resp,Response for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_TTR,CPWD_A_CPWD_TRIAL000030_TTR,CPWD_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_TRIAL,CPWD_A_CPWD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_QID,CPWD_A_CPWD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_CORR,CPWD_A_CPWD_TRIAL000030_CORR,CPWD_q30_corr,Response correct for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_RESP,CPWD_A_CPWD_TRIAL000031_RESP,CPWD_q31_resp,Response for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_TTR,CPWD_A_CPWD_TRIAL000031_TTR,CPWD_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_TRIAL,CPWD_A_CPWD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_QID,CPWD_A_CPWD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_CORR,CPWD_A_CPWD_TRIAL000031_CORR,CPWD_q31_corr,Response correct for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_RESP,CPWD_A_CPWD_TRIAL000032_RESP,CPWD_q32_resp,Response for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_TTR,CPWD_A_CPWD_TRIAL000032_TTR,CPWD_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_TRIAL,CPWD_A_CPWD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_QID,CPWD_A_CPWD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_CORR,CPWD_A_CPWD_TRIAL000032_CORR,CPWD_q32_corr,Response correct for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_RESP,CPWD_A_CPWD_TRIAL000033_RESP,CPWD_q33_resp,Response for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_TTR,CPWD_A_CPWD_TRIAL000033_TTR,CPWD_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_TRIAL,CPWD_A_CPWD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_QID,CPWD_A_CPWD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_CORR,CPWD_A_CPWD_TRIAL000033_CORR,CPWD_q33_corr,Response correct for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_RESP,CPWD_A_CPWD_TRIAL000034_RESP,CPWD_q34_resp,Response for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_TTR,CPWD_A_CPWD_TRIAL000034_TTR,CPWD_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_TRIAL,CPWD_A_CPWD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_QID,CPWD_A_CPWD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_CORR,CPWD_A_CPWD_TRIAL000034_CORR,CPWD_q34_corr,Response correct for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_RESP,CPWD_A_CPWD_TRIAL000035_RESP,CPWD_q35_resp,Response for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_TTR,CPWD_A_CPWD_TRIAL000035_TTR,CPWD_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_TRIAL,CPWD_A_CPWD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_QID,CPWD_A_CPWD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_CORR,CPWD_A_CPWD_TRIAL000035_CORR,CPWD_q35_corr,Response correct for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_RESP,CPWD_A_CPWD_TRIAL000036_RESP,CPWD_q36_resp,Response for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_TTR,CPWD_A_CPWD_TRIAL000036_TTR,CPWD_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_TRIAL,CPWD_A_CPWD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_QID,CPWD_A_CPWD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_CORR,CPWD_A_CPWD_TRIAL000036_CORR,CPWD_q36_corr,Response correct for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_RESP,CPWD_A_CPWD_TRIAL000037_RESP,CPWD_q37_resp,Response for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_TTR,CPWD_A_CPWD_TRIAL000037_TTR,CPWD_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_TRIAL,CPWD_A_CPWD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_QID,CPWD_A_CPWD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_CORR,CPWD_A_CPWD_TRIAL000037_CORR,CPWD_q37_corr,Response correct for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_RESP,CPWD_A_CPWD_TRIAL000038_RESP,CPWD_q38_resp,Response for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_TTR,CPWD_A_CPWD_TRIAL000038_TTR,CPWD_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_TRIAL,CPWD_A_CPWD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_QID,CPWD_A_CPWD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_CORR,CPWD_A_CPWD_TRIAL000038_CORR,CPWD_q38_corr,Response correct for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_RESP,CPWD_A_CPWD_TRIAL000039_RESP,CPWD_q39_resp,Response for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_TTR,CPWD_A_CPWD_TRIAL000039_TTR,CPWD_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_TRIAL,CPWD_A_CPWD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_QID,CPWD_A_CPWD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_CORR,CPWD_A_CPWD_TRIAL000039_CORR,CPWD_q39_corr,Response correct for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_RESP,CPWD_A_CPWD_TRIAL000040_RESP,CPWD_q40_resp,Response for trial 40,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_TTR,CPWD_A_CPWD_TRIAL000040_TTR,CPWD_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_TRIAL,CPWD_A_CPWD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_QID,CPWD_A_CPWD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_CORR,CPWD_A_CPWD_TRIAL000040_CORR,CPWD_q40_corr,Response correct for trial 40,Penn Word Memory Test - Delayed Version
+MPRACT_ScorVers,MPRACT_ScorVers,MPRACT,Current Programming Version of the Scoring Code,Motor Praxis Test
+MPRACT_status,MPRACT_status,MPRACT_status,Status Code Assigned to Mouse Praxis ,Motor Praxis Test
+MPRACT_valid_code,MPRACT_valid_code,MPRACT_valid_code,Valid Code Assigned to Mouse Praxis,Motor Praxis Test
+MPRACT_MP1RT,MPRACT_MP1RT,MPRACT_MP1RT,Median Response Time for Mouse Praxis Trial 1 (ms),Motor Praxis Test
+MPRACT_MP2,MPRACT_MP2,MPRACT_MP2,Mouse Praxis Correct Responses Trial 2,Motor Praxis Test
+MPRACT_MP2RTCR,MPRACT_MP2RTCR,MPRACT_MP2RTCR,Median Response Time for Mouse Praxis Trial 2 Correct Responses (ms),Motor Praxis Test
+PCET_A_ScorVers,PCET_A_ScorVers,PCET,Current Programming Version of the Scoring Code,Penn Conditional Exclusion Test - Form A
+PCET_A_status,PCET_A_status,PCET_status,Status Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
+PCET_A_valid_code,PCET_A_valid_code,PCET_valid_code,Valid Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CR,PCET_A_PCET_CR,PCET_PCETCR,PCET Number Correct Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RTCR,PCET_A_PCET_RTCR,PCET_PCETRTCR,Median Response Time for PCET Correct Responses (ms),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ER,PCET_A_PCET_ER,PCET_PCETER,PCET Number Incorrect Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RTER,PCET_A_PCET_RTER,PCET_PCETRTER,Median Response Time for PCET Incorrect Responses (ms),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_WIS_PER_ER,PCET_A_PCET_WIS_PER_ER,PCET_PER_ER,PCET Number of Perseverative Errors,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_WIS_PER_RES,PCET_A_PCET_WIS_PER_RES,PCET_PER_RES,PCET Perseverative Errors Plus Correct Perseverative Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_EFF,PCET_A_PCET_EFF,PCET_PCET_EFF,PCET Efficiency = PCET_ACC/log(PCETRTCR),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_NUM,PCET_A_PCET_NUM,PCET_PCET_NUM,Total Number of Trials,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT,PCET_A_PCET_CAT,PCET_PCET_CAT,Number of PCET Categories Achieved,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT1_TR,PCET_A_PCET_CAT1_TR,PCET_CAT1_tr,Number of Trials Required to Achieve Category 1,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT2_TR,PCET_A_PCET_CAT2_TR,PCET_CAT2_tr,Number of Trials Required to Achieve Category 2,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT3_TR,PCET_A_PCET_CAT3_TR,PCET_CAT3_tr,Number of Trials Required to Achieve Category 3,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ACC,PCET_A_PCET_ACC,PCET_PCET_ACC,PCET Accuracy = PCET_CAT * PCETCR/(PCETCR +PCETER),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ACC2,PCET_A_PCET_ACC2,PCET_PCET_ACC2,PECT Accuracy2 = (PCET_CAT+1)*PCETCR/(PCETCR+PCETER),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RT,PCET_A_PCET_RT,,Median Response Time for All Responses (ms),Penn Conditional Exclusion Test - Form A
+PMAT24_A_ScorVers,PMAT24_A_ScorVers,PMAT,Current Programming Version of the Scoring Code,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_FORM,PMAT24_A_PMAT24_A_FORM,PMAT24A_PMAT24_FORM,Form of this administration,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_valid_code,PMAT24_A_valid_code,PMAT24A_status,Status Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_CR,PMAT24_A_PMAT24_A_CR,PMAT24A_valid_code,Valid Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_PC,PMAT24_A_PMAT24_A_PC,PMAT24A_PMAT24_A_CR,PMAT24 Correct Responses for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_SI,PMAT24_A_PMAT24_A_SI,PMAT24A_PMAT24_A_SI,PMAT24 Total Skipped Items (items not presented because maximum errors allowed reached) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTCR,PMAT24_A_PMAT24_A_RTCR,PMAT24A_PMAT24_A_RTCR,Median Response Time for Correct PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTER,PMAT24_A_PMAT24_A_RTER,PMAT24A_PMAT24_A_RTER,Median Response Time for Incorrect PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTTO,PMAT24_A_PMAT24_A_RTTO,PMAT24A_PMAT24_A_RTTO,Median Resposne Time for All PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_RESP,PMAT24_A_PMAT24_A_QID000001_RESP,PMAT24A_q01_resp,Response for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_TTR,PMAT24_A_PMAT24_A_QID000001_TTR,PMAT24A_q01_ttr,Time to respond (ms) for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_TRIAL,PMAT24_A_PMAT24_A_QID000001_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_QID,PMAT24_A_PMAT24_A_QID000001_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_CORR,PMAT24_A_PMAT24_A_QID000001_CORR,PMAT24A_q01_corr,Response correct for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_RESP,PMAT24_A_PMAT24_A_QID000002_RESP,PMAT24A_q02_resp,Response for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_TTR,PMAT24_A_PMAT24_A_QID000002_TTR,PMAT24A_q02_ttr,Time to respond (ms) for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_TRIAL,PMAT24_A_PMAT24_A_QID000002_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_QID,PMAT24_A_PMAT24_A_QID000002_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_CORR,PMAT24_A_PMAT24_A_QID000002_CORR,PMAT24A_q02_corr,Response correct for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_RESP,PMAT24_A_PMAT24_A_QID000003_RESP,PMAT24A_q03_resp,Response for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_TTR,PMAT24_A_PMAT24_A_QID000003_TTR,PMAT24A_q03_ttr,Time to respond (ms) for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_TRIAL,PMAT24_A_PMAT24_A_QID000003_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_QID,PMAT24_A_PMAT24_A_QID000003_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_CORR,PMAT24_A_PMAT24_A_QID000003_CORR,PMAT24A_q03_corr,Response correct for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_RESP,PMAT24_A_PMAT24_A_QID000004_RESP,PMAT24A_q04_resp,Response for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_TTR,PMAT24_A_PMAT24_A_QID000004_TTR,PMAT24A_q04_ttr,Time to respond (ms) for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_TRIAL,PMAT24_A_PMAT24_A_QID000004_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_QID,PMAT24_A_PMAT24_A_QID000004_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_CORR,PMAT24_A_PMAT24_A_QID000004_CORR,PMAT24A_q04_corr,Response correct for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_RESP,PMAT24_A_PMAT24_A_QID000005_RESP,PMAT24A_q05_resp,Response for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_TTR,PMAT24_A_PMAT24_A_QID000005_TTR,PMAT24A_q05_ttr,Time to respond (ms) for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_TRIAL,PMAT24_A_PMAT24_A_QID000005_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_QID,PMAT24_A_PMAT24_A_QID000005_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_CORR,PMAT24_A_PMAT24_A_QID000005_CORR,PMAT24A_q05_corr,Response correct for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_RESP,PMAT24_A_PMAT24_A_QID000006_RESP,PMAT24A_q06_resp,Response for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_TTR,PMAT24_A_PMAT24_A_QID000006_TTR,PMAT24A_q06_ttr,Time to respond (ms) for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_TRIAL,PMAT24_A_PMAT24_A_QID000006_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_QID,PMAT24_A_PMAT24_A_QID000006_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_CORR,PMAT24_A_PMAT24_A_QID000006_CORR,PMAT24A_q06_corr,Response correct for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_RESP,PMAT24_A_PMAT24_A_QID000007_RESP,PMAT24A_q07_resp,Response for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_TTR,PMAT24_A_PMAT24_A_QID000007_TTR,PMAT24A_q07_ttr,Time to respond (ms) for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_TRIAL,PMAT24_A_PMAT24_A_QID000007_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_QID,PMAT24_A_PMAT24_A_QID000007_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_CORR,PMAT24_A_PMAT24_A_QID000007_CORR,PMAT24A_q07_corr,Response correct for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_RESP,PMAT24_A_PMAT24_A_QID000008_RESP,PMAT24A_q08_resp,Response for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_TTR,PMAT24_A_PMAT24_A_QID000008_TTR,PMAT24A_q08_ttr,Time to respond (ms) for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_TRIAL,PMAT24_A_PMAT24_A_QID000008_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_QID,PMAT24_A_PMAT24_A_QID000008_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_CORR,PMAT24_A_PMAT24_A_QID000008_CORR,PMAT24A_q08_corr,Response correct for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_RESP,PMAT24_A_PMAT24_A_QID000009_RESP,PMAT24A_q09_resp,Response for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_TTR,PMAT24_A_PMAT24_A_QID000009_TTR,PMAT24A_q09_ttr,Time to respond (ms) for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_TRIAL,PMAT24_A_PMAT24_A_QID000009_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_QID,PMAT24_A_PMAT24_A_QID000009_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_CORR,PMAT24_A_PMAT24_A_QID000009_CORR,PMAT24A_q09_corr,Response correct for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_RESP,PMAT24_A_PMAT24_A_QID000010_RESP,PMAT24A_q10_resp,Response for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_TTR,PMAT24_A_PMAT24_A_QID000010_TTR,PMAT24A_q10_ttr,Time to respond (ms) for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_TRIAL,PMAT24_A_PMAT24_A_QID000010_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_QID,PMAT24_A_PMAT24_A_QID000010_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_CORR,PMAT24_A_PMAT24_A_QID000010_CORR,PMAT24A_q10_corr,Response correct for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_RESP,PMAT24_A_PMAT24_A_QID000011_RESP,PMAT24A_q11_resp,Response for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_TTR,PMAT24_A_PMAT24_A_QID000011_TTR,PMAT24A_q11_ttr,Time to respond (ms) for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_TRIAL,PMAT24_A_PMAT24_A_QID000011_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_QID,PMAT24_A_PMAT24_A_QID000011_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_CORR,PMAT24_A_PMAT24_A_QID000011_CORR,PMAT24A_q11_corr,Response correct for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_RESP,PMAT24_A_PMAT24_A_QID000012_RESP,PMAT24A_q12_resp,Response for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_TTR,PMAT24_A_PMAT24_A_QID000012_TTR,PMAT24A_q12_ttr,Time to respond (ms) for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_TRIAL,PMAT24_A_PMAT24_A_QID000012_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_QID,PMAT24_A_PMAT24_A_QID000012_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_CORR,PMAT24_A_PMAT24_A_QID000012_CORR,PMAT24A_q12_corr,Response correct for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_RESP,PMAT24_A_PMAT24_A_QID000013_RESP,PMAT24A_q13_resp,Response for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_TTR,PMAT24_A_PMAT24_A_QID000013_TTR,PMAT24A_q13_ttr,Time to respond (ms) for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_TRIAL,PMAT24_A_PMAT24_A_QID000013_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_QID,PMAT24_A_PMAT24_A_QID000013_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_CORR,PMAT24_A_PMAT24_A_QID000013_CORR,PMAT24A_q13_corr,Response correct for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_RESP,PMAT24_A_PMAT24_A_QID000014_RESP,PMAT24A_q14_resp,Response for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_TTR,PMAT24_A_PMAT24_A_QID000014_TTR,PMAT24A_q14_ttr,Time to respond (ms) for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_TRIAL,PMAT24_A_PMAT24_A_QID000014_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_QID,PMAT24_A_PMAT24_A_QID000014_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_CORR,PMAT24_A_PMAT24_A_QID000014_CORR,PMAT24A_q14_corr,Response correct for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_RESP,PMAT24_A_PMAT24_A_QID000015_RESP,PMAT24A_q15_resp,Response for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_TTR,PMAT24_A_PMAT24_A_QID000015_TTR,PMAT24A_q15_ttr,Time to respond (ms) for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_TRIAL,PMAT24_A_PMAT24_A_QID000015_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_QID,PMAT24_A_PMAT24_A_QID000015_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_CORR,PMAT24_A_PMAT24_A_QID000015_CORR,PMAT24A_q15_corr,Response correct for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_RESP,PMAT24_A_PMAT24_A_QID000016_RESP,PMAT24A_q16_resp,Response for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_TTR,PMAT24_A_PMAT24_A_QID000016_TTR,PMAT24A_q16_ttr,Time to respond (ms) for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_TRIAL,PMAT24_A_PMAT24_A_QID000016_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_QID,PMAT24_A_PMAT24_A_QID000016_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_CORR,PMAT24_A_PMAT24_A_QID000016_CORR,PMAT24A_q16_corr,Response correct for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_RESP,PMAT24_A_PMAT24_A_QID000017_RESP,PMAT24A_q17_resp,Response for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_TTR,PMAT24_A_PMAT24_A_QID000017_TTR,PMAT24A_q17_ttr,Time to respond (ms) for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_TRIAL,PMAT24_A_PMAT24_A_QID000017_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_QID,PMAT24_A_PMAT24_A_QID000017_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_CORR,PMAT24_A_PMAT24_A_QID000017_CORR,PMAT24A_q17_corr,Response correct for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_RESP,PMAT24_A_PMAT24_A_QID000018_RESP,PMAT24A_q18_resp,Response for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_TTR,PMAT24_A_PMAT24_A_QID000018_TTR,PMAT24A_q18_ttr,Time to respond (ms) for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_TRIAL,PMAT24_A_PMAT24_A_QID000018_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_QID,PMAT24_A_PMAT24_A_QID000018_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_CORR,PMAT24_A_PMAT24_A_QID000018_CORR,PMAT24A_q18_corr,Response correct for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_RESP,PMAT24_A_PMAT24_A_QID000019_RESP,PMAT24A_q19_resp,Response for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_TTR,PMAT24_A_PMAT24_A_QID000019_TTR,PMAT24A_q19_ttr,Time to respond (ms) for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_TRIAL,PMAT24_A_PMAT24_A_QID000019_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_QID,PMAT24_A_PMAT24_A_QID000019_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_CORR,PMAT24_A_PMAT24_A_QID000019_CORR,PMAT24A_q19_corr,Response correct for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_RESP,PMAT24_A_PMAT24_A_QID000020_RESP,PMAT24A_q20_resp,Response for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_TTR,PMAT24_A_PMAT24_A_QID000020_TTR,PMAT24A_q20_ttr,Time to respond (ms) for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_TRIAL,PMAT24_A_PMAT24_A_QID000020_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_QID,PMAT24_A_PMAT24_A_QID000020_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_CORR,PMAT24_A_PMAT24_A_QID000020_CORR,PMAT24A_q20_corr,Response correct for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_RESP,PMAT24_A_PMAT24_A_QID000021_RESP,PMAT24A_q21_resp,Response for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_TTR,PMAT24_A_PMAT24_A_QID000021_TTR,PMAT24A_q21_ttr,Time to respond (ms) for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_TRIAL,PMAT24_A_PMAT24_A_QID000021_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_QID,PMAT24_A_PMAT24_A_QID000021_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_CORR,PMAT24_A_PMAT24_A_QID000021_CORR,PMAT24A_q21_corr,Response correct for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_RESP,PMAT24_A_PMAT24_A_QID000022_RESP,PMAT24A_q22_resp,Response for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_TTR,PMAT24_A_PMAT24_A_QID000022_TTR,PMAT24A_q22_ttr,Time to respond (ms) for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_TRIAL,PMAT24_A_PMAT24_A_QID000022_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_QID,PMAT24_A_PMAT24_A_QID000022_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_CORR,PMAT24_A_PMAT24_A_QID000022_CORR,PMAT24A_q22_corr,Response correct for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_RESP,PMAT24_A_PMAT24_A_QID000023_RESP,PMAT24A_q23_resp,Response for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_TTR,PMAT24_A_PMAT24_A_QID000023_TTR,PMAT24A_q23_ttr,Time to respond (ms) for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_TRIAL,PMAT24_A_PMAT24_A_QID000023_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_QID,PMAT24_A_PMAT24_A_QID000023_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_CORR,PMAT24_A_PMAT24_A_QID000023_CORR,,Response correct for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_RESP,PMAT24_A_PMAT24_A_QID000024_RESP,PMAT24A_q23_corr,Response for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_TTR,PMAT24_A_PMAT24_A_QID000024_TTR,PMAT24A_q24_resp,Time to respond (ms) for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_TRIAL,PMAT24_A_PMAT24_A_QID000024_TRIAL,PMAT24A_q24_ttr,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_QID,PMAT24_A_PMAT24_A_QID000024_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_CORR,PMAT24_A_PMAT24_A_QID000024_CORR,PMAT24A_q24_corr,Response correct for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PVOC_ScorVers,PVOC_ScorVers,PVOC_Scorvers,Current Programming Version of the Scoring Code,Penn Vocabulary Test
+PVOC_status,PVOC_status,PVOC_status,Status Code Assigned to PVOC,Penn Vocabulary Test
+PVOC_valid_code,PVOC_valid_code,PVOC_valid_code,Valid Code Assigned to PVOC,Penn Vocabulary Test
+PVOC_PVOC1,PVOC_PVOC1,PVOC_PVOC1,PVOC Correct Responses for Items 1-10,Penn Vocabulary Test
+PVOC_PVOC2,PVOC_PVOC2,PVOC_PVOC2,PVOC Correct Responses for Items 11-20,Penn Vocabulary Test
+PVOC_PVOC3,PVOC_PVOC3,PVOC_PVOC3,PVOC Correct Responses for Items 21-30,Penn Vocabulary Test
+PVOC_PVOC4,PVOC_PVOC4,PVOC_PVOC4,PVOC Correct Responses for Items 31-40,Penn Vocabulary Test
+PVOC_PVOC5,PVOC_PVOC5,PVOC_PVOC5,PVOC Correct Responses for Items 41-50,Penn Vocabulary Test
+PVOC_PVOCCR,PVOC_PVOCCR,PVOC_PVOCCR,PVOC Total Correct Responses,Penn Vocabulary Test
+PVOC_PVOCNR,PVOC_PVOCNR,PVOC_PVOCNR,PVOC Total Non-Responses,Penn Vocabulary Test
+PVOC_PVOC1RTCR,PVOC_PVOC1RTCR,PVOC_PVOC1RTCR,Median Response Time for correct PVOC1 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC2RTCR,PVOC_PVOC2RTCR,PVOC_PVOC2RTCR,Median Response Time for correct PVOC2 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC3RTCR,PVOC_PVOC3RTCR,PVOC_PVOC3RTCR,Median Response Time for correct PVOC3 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC4RTCR,PVOC_PVOC4RTCR,PVOC_PVOC4RTCR,Median Response Time for correct PVOC4 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC5RTCR,PVOC_PVOC5RTCR,PVOC_PVOC5RTCR,Median Response Time for correct PVOC5 Trials (ms),Penn Vocabulary Test
+PVOC_PVOCRTCR,PVOC_PVOCRTCR,PVOC_PVOCRTCR,Median Response Time for correct PVOC (All Trials) (ms),Penn Vocabulary Test
+PVOC_PVOC1RTER,PVOC_PVOC1RTER,PVOC_PVOC1RTER,Median Response Time for incorrect PVOC1 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC2RTER,PVOC_PVOC2RTER,PVOC_PVOC2RTER,Median Response Time for incorrect PVOC2 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC3RTER,PVOC_PVOC3RTER,PVOC_PVOC3RTER,Median Response Time for incorrect PVOC3 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC4RTER,PVOC_PVOC4RTER,PVOC_PVOC4RTER,Median Response Time for incorrect PVOC4 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC5RTER,PVOC_PVOC5RTER,PVOC_PVOC5RTER,Median Response Time for incorrect PVOC5 Trials (ms),Penn Vocabulary Test
+PVOC_PVOCRTER,PVOC_PVOCRTER,PVOC_PVOCRTER,Median Response Time for incorrect PVOC (All Trials) (ms),Penn Vocabulary Test
+PVOC_PVOC_Q1,PVOC_PVOC_Q1,PVOC_PVOC_Q1,PVOC Q1: Were all of the instructions clear?,Penn Vocabulary Test
+PVOC_PVOC_Q2,PVOC_PVOC_Q2,PVOC_PVOC_Q2,PVOC Q2: Did you have enough time to complete each item?,Penn Vocabulary Test
+PVOC_PVOC_Q3,PVOC_PVOC_Q3,PVOC_PVOC_Q3,PVOC Q3: Are you a native speaker of English?,Penn Vocabulary Test
+PVOC_PVOC_Q4,PVOC_PVOC_Q4,PVOC_PVOC_Q4,"PVOC Q4: If no, at what age did you learn English?",Penn Vocabulary Test
+PVOC_PVOC_Q5,PVOC_PVOC_Q5,PVOC_PVOC_Q5,PVOC Q5: Most recent Verbal SAT score,Penn Vocabulary Test
+PVOC_PVOC_Q6,PVOC_PVOC_Q6,PVOC_PVOC_Q6,PVOC Q6: Most recent Math SAT score,Penn Vocabulary Test
+PVOC_PVOC_Q7,PVOC_PVOC_Q7,PVOC_PVOC_Q7,PVOC Q7: SAT Year Taken,Penn Vocabulary Test
+PVOC_RES_1,PVOC_RES_1,PVOC_RES_1,Response for Item 1,Penn Vocabulary Test
+PVOC_RES_2,PVOC_RES_2,PVOC_RES_2,Response for Item 2,Penn Vocabulary Test
+PVOC_RES_3,PVOC_RES_3,PVOC_RES_3,Response for Item 3,Penn Vocabulary Test
+PVOC_RES_4,PVOC_RES_4,PVOC_RES_4,Response for Item 4,Penn Vocabulary Test
+PVOC_RES_5,PVOC_RES_5,PVOC_RES_5,Response for Item 5,Penn Vocabulary Test
+PVOC_RES_6,PVOC_RES_6,PVOC_RES_6,Response for Item 6,Penn Vocabulary Test
+PVOC_RES_7,PVOC_RES_7,PVOC_RES_7,Response for Item 7,Penn Vocabulary Test
+PVOC_RES_8,PVOC_RES_8,PVOC_RES_8,Response for Item 8,Penn Vocabulary Test
+PVOC_RES_9,PVOC_RES_9,PVOC_RES_9,Response for Item 9,Penn Vocabulary Test
+PVOC_RES_10,PVOC_RES_10,PVOC_RES_10,Response for Item 10,Penn Vocabulary Test
+PVOC_RES_11,PVOC_RES_11,PVOC_RES_11,Response for Item 11,Penn Vocabulary Test
+PVOC_RES_12,PVOC_RES_12,PVOC_RES_12,Response for Item 12,Penn Vocabulary Test
+PVOC_RES_13,PVOC_RES_13,PVOC_RES_13,Response for Item 13,Penn Vocabulary Test
+PVOC_RES_14,PVOC_RES_14,PVOC_RES_14,Response for Item 14,Penn Vocabulary Test
+PVOC_RES_15,PVOC_RES_15,PVOC_RES_15,Response for Item 15,Penn Vocabulary Test
+PVOC_RES_16,PVOC_RES_16,PVOC_RES_16,Response for Item 16,Penn Vocabulary Test
+PVOC_RES_17,PVOC_RES_17,PVOC_RES_17,Response for Item 17,Penn Vocabulary Test
+PVOC_RES_18,PVOC_RES_18,PVOC_RES_18,Response for Item 18,Penn Vocabulary Test
+PVOC_RES_19,PVOC_RES_19,PVOC_RES_19,Response for Item 19,Penn Vocabulary Test
+PVOC_RES_20,PVOC_RES_20,PVOC_RES_20,Response for Item 20,Penn Vocabulary Test
+PVOC_RES_21,PVOC_RES_21,PVOC_RES_21,Response for Item 21,Penn Vocabulary Test
+PVOC_RES_22,PVOC_RES_22,PVOC_RES_22,Response for Item 22,Penn Vocabulary Test
+PVOC_RES_23,PVOC_RES_23,PVOC_RES_23,Response for Item 23,Penn Vocabulary Test
+PVOC_RES_24,PVOC_RES_24,PVOC_RES_24,Response for Item 24,Penn Vocabulary Test
+PVOC_RES_25,PVOC_RES_25,PVOC_RES_25,Response for Item 25,Penn Vocabulary Test
+PVOC_RES_26,PVOC_RES_26,PVOC_RES_26,Response for Item 26,Penn Vocabulary Test
+PVOC_RES_27,PVOC_RES_27,PVOC_RES_27,Response for Item 27,Penn Vocabulary Test
+PVOC_RES_28,PVOC_RES_28,PVOC_RES_28,Response for Item 28,Penn Vocabulary Test
+PVOC_RES_29,PVOC_RES_29,PVOC_RES_29,Response for Item 29,Penn Vocabulary Test
+PVOC_RES_30,PVOC_RES_30,PVOC_RES_30,Response for Item 30,Penn Vocabulary Test
+PVOC_RES_31,PVOC_RES_31,PVOC_RES_31,Response for Item 31,Penn Vocabulary Test
+PVOC_RES_32,PVOC_RES_32,PVOC_RES_32,Response for Item 32,Penn Vocabulary Test
+PVOC_RES_33,PVOC_RES_33,PVOC_RES_33,Response for Item 33,Penn Vocabulary Test
+PVOC_RES_34,PVOC_RES_34,PVOC_RES_34,Response for Item 34,Penn Vocabulary Test
+PVOC_RES_35,PVOC_RES_35,PVOC_RES_35,Response for Item 35,Penn Vocabulary Test
+PVOC_RES_36,PVOC_RES_36,PVOC_RES_36,Response for Item 36,Penn Vocabulary Test
+PVOC_RES_37,PVOC_RES_37,PVOC_RES_37,Response for Item 37,Penn Vocabulary Test
+PVOC_RES_38,PVOC_RES_38,PVOC_RES_38,Response for Item 38,Penn Vocabulary Test
+PVOC_RES_39,PVOC_RES_39,PVOC_RES_39,Response for Item 39,Penn Vocabulary Test
+PVOC_RES_40,PVOC_RES_40,PVOC_RES_40,Response for Item 40,Penn Vocabulary Test
+PVOC_RES_41,PVOC_RES_41,PVOC_RES_41,Response for Item 41,Penn Vocabulary Test
+PVOC_RES_42,PVOC_RES_42,PVOC_RES_42,Response for Item 42,Penn Vocabulary Test
+PVOC_RES_43,PVOC_RES_43,PVOC_RES_43,Response for Item 43,Penn Vocabulary Test
+PVOC_RES_44,PVOC_RES_44,PVOC_RES_44,Response for Item 44,Penn Vocabulary Test
+PVOC_RES_45,PVOC_RES_45,PVOC_RES_45,Response for Item 45,Penn Vocabulary Test
+PVOC_RES_46,PVOC_RES_46,PVOC_RES_46,Response for Item 46,Penn Vocabulary Test
+PVOC_RES_47,PVOC_RES_47,PVOC_RES_47,Response for Item 47,Penn Vocabulary Test
+PVOC_RES_48,PVOC_RES_48,PVOC_RES_48,Response for Item 48,Penn Vocabulary Test
+PVOC_RES_49,PVOC_RES_49,PVOC_RES_49,Response for Item 49,Penn Vocabulary Test
+PVOC_RES_50,PVOC_RES_50,PVOC_RES_50,Response for Item 50,Penn Vocabulary Test
+PVRT_ScorVers,PVRT_ScorVers,SPVRT,Current Programming Version of the Scoring Code,Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_FORM,PVRT_PVRT_FORM,,Form of the PVRT,Penn Logical Reasoning Test - Short Version
+PVRT_status,PVRT_status,PVRT_status,Status Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_valid_code,PVRT_valid_code,PVRT_valid_code,Valid Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTCR,PVRT_PVRTCR,PVRT_PVRTCR,Correct Responses for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_PC,PVRT_PVRT_PC,PVRT_PVRT_PC,Percent Correct for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTTO,PVRT_PVRTRTTO,PVRT_PVRTRTTO,All Responses Median Response Time (ms) for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTCR,PVRT_PVRTRTCR,PVRT_PVRTRTCR,SPVRT Median Response Time for Correct Responses (ms),Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTER,PVRT_PVRTRTER,PVRT_PVRTRTER,SPVRT Median Response Time for Incorrect Responses (ms),Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_EFF,PVRT_PVRT_EFF,PVRT_PVRT_EFF,PVRT Efficiency = PVRT_PC/log(PVRTRTCR),Penn Logical Reasoning Test - Short Version
+SVOLT_A_ScorVers,SHORTVOLT_ScorVers,SVOLT,Current Programming Version of the Scoring Code,Visual Object Learning Test - Short Version
+SVOLT_A_status,SHORTVOLT_status,SHORTVOLT_status,Status Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SVOLT_A_valid_code,SHORTVOLT_valid_code,SHORTVOLT_valid_code,Valid Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_CR,SHORTVOLT_SVT,SHORTVOLT_SVT,SVOLT Total Correct,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_RT,SHORTVOLT_SVTRT,SHORTVOLT_SVTRT,Median Response Time for Short VOLT All Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_RTCR,SHORTVOLT_SVTCRT,SHORTVOLT_SVTCRT,Median Response Time for SVOLT Correct Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_W_RTCR,,,Weighted Median Response Time for Correct Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_RTER,SHORTVOLT_SVTIRT,SHORTVOLT_SVTIRT,Median Response Time for SVOLT Incorrect Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_W_RTER,,,Weighted Median Response Time for Incorrect Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TP,SHORTVOLT_SVTTP,SHORTVOLT_SVTTP,SVOLT True Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TN,SHORTVOLT_SVTTN,SHORTVOLT_SVTTN,SVOLT True Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FP,SHORTVOLT_SVTFP,SHORTVOLT_SVTFP,SVOLT False Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FN,SHORTVOLT_SVTFN,SHORTVOLT_SVTFN,SVOLT False Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TPRT,SHORTVOLT_SVTTPRT,SHORTVOLT_SVTTPRT,SVOLT True Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TNRT,SHORTVOLT_SVTTNRT,SHORTVOLT_SVTTNRT,SVOLT True Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FPRT,SHORTVOLT_SVTFPRT,SHORTVOLT_SVTFPRT,SVOLT False Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FNRT,SHORTVOLT_SVTFNRT,SHORTVOLT_SVTFNRT,SVOLT False Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_ER,,,Total Incorrect Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DY,,,Total Definitely Yes Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DN,,,Total Definitely No Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PY,,,Total Probably Yes Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PN,,,Total Probably No Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DTP,,,Total Definitely True Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PTP,,,Total Probably True Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DTN,,,Total Definitely True Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PTN,,,Total Probably True Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DFP,,,Total Definitely False Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PFP,,,Total Probably False Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_DFN,,,Total Definitely False Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_PFN,,,Total Probably False Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_EFF,SHORTVOLT_SVT_EFF,SHORTVOLT_SVT_EFF,Short VOLT Efficiency ,Visual Object Learning Test - Short Version
+SPCPTNL_ScorVers,SPCPTNL_ScorVers,SPCPTNL,Current Programming Version of the Scoring Code,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_status,SPCPTNL_status,SPCPTNL_status,Status Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_valid_code,SPCPTNL_valid_code,SPCPTNL_valid_code,Valid Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TP,SPCPTNL_SCPN_TP,SPCPTNL_SCPN_TP,NumLet True Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FP,SPCPTNL_SCPN_FP,SPCPTNL_SCPN_FP,NumLet False Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TN,SPCPTNL_SCPN_TN,SPCPTNL_SCPN_TN,NumLet True Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FN,SPCPTNL_SCPN_FN,SPCPTNL_SCPN_FN,NumLet False Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TPRT,SPCPTNL_SCPN_TPRT,SPCPTNL_SCPN_TPRT,Median Response Time for NumLet True Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FPRT,SPCPTNL_SCPN_FPRT,SPCPTNL_SCPN_FPRT,Median Response Time for NumLet False Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TP,SPCPTNL_SCPL_TP,SPCPTNL_SCPL_TP,NumLet True Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FP,SPCPTNL_SCPL_FP,SPCPTNL_SCPL_FP,NumLet False Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TN,SPCPTNL_SCPL_TN,SPCPTNL_SCPL_TN,NumLet True Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FN,SPCPTNL_SCPL_FN,SPCPTNL_SCPL_FN,NumLet False Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TPRT,SPCPTNL_SCPL_TPRT,SPCPTNL_SCPL_TPRT,Median Response Time for NumLet True Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FPRT,SPCPTNL_SCPL_FPRT,SPCPTNL_SCPL_FPRT,Median Response Time for NumLet False Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FN,SPCPTNL_SCPT_FN,SPCPTNL_SCPT_FN,NumLet CPT False Negatives - Sum of SCPN_FN and SCPL_FN,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FP,SPCPTNL_SCPT_FP,SPCPTNL_SCPT_FP,NumLet CPT False Positives - Sum of SCPN_FP and SCPL_FP,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TP,SPCPTNL_SCPT_TP,SPCPTNL_SCPT_TP,NumLet CPT True Positives - Sum of SCPN_TP and SCPL_TP,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TN,SPCPTNL_SCPT_TN,SPCPTNL_SCPT_TN,NumLet CPT True Negatives - Sum of SCPN_TN and SCPL_TN,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TPRT,SPCPTNL_SCPT_TPRT,SPCPTNL_SCPT_TPRT,Median Response Time for NumLet True Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FPRT,SPCPTNL_SCPT_FPRT,SPCPTNL_SCPT_FPRT,Median Response Time for NumLet False Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_RT,SPCPTNL_SCPN_RT,,Median Response Time for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_RT,SPCPTNL_SCPL_RT,,Median Response Time for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_RT,SPCPTNL_SCPT_RT,,Median Response Time for All Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_SEN,SPCPTNL_SCPT_SEN,,Sensitivity = SCPT_TP/(SCPT_TP + SCPT_FN),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_SPEC,SPCPTNL_SCPT_SPEC,,Specificity = SCPT_TN/(SCPT_TN + SCPT_FP),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_LRNR,SPCPTNL_SCPT_LRNR,SPCPTNL_SCPT_LRNR,NumLet CPT Longest Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,NumLet CPT Final Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
+SVOLTD_A_ScorVers,SVOLTD_A_ScorVers,SVOLTD,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_status,SVOLTD_A_status,SVDELAY_status,Status Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_valid_code,SVOLTD_A_valid_code,SVDELAY_valid_code,Valid Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LD,SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVTLDRTC,SVOLTD_A_SVTLDRTC,SVDELAY_SVTLDRTC,Median Response Time for SVOLTD Correct Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVTLDRTER,SVOLTD_A_SVTLDRTER,SVDELAY_SVTLDRTER,Median Response Time for SVOLTD Incorrect Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTP,SVOLTD_A_SVT_LDTP,SVDELAY_SVT_LDTP,SVOLTD True Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTN,SVOLTD_A_SVT_LDTN,SVDELAY_SVT_LDTN,SVOLTD True Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFP,SVOLTD_A_SVT_LDFP,SVDELAY_SVT_LDFP,SVOLTD False Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFN,SVOLTD_A_SVT_LDFN,SVDELAY_SVT_LDFN,SVOLTD False Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTPRT,SVOLTD_A_SVT_LDTPRT,SVDELAY_SVT_LDTPRT,SVOLTD True Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTNRT,SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFPRT,SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFNRT,SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_EFFD,SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
+SFNB2_ScorVers,SFNB2_ScorVers,SFNB2,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
+SFNB2_status,SFNB2_status,SFNB2_status,SFNB2 completion status,Short Fractal-N-Back- 2 Back Version
+SFNB2_valid_code,SFNB2_valid_code,SFNB2_valid_code,SFNB2 valid code,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP,SFNB2_SFNB_TP,SFNB2_SFNB_TP,SFNB2 True Positive Responses,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP,SFNB2_SFNB_FP,SFNB2_SFNB_FP,SFNB2 False Positive Responses,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC,SFNB2_SFNB_RTC,SFNB2_SFNB_RTC,SFNB2 Median Response Time for All Correct Responses (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP0,SFNB2_SFNB_TP0,SFNB2_SFNB_TP0,SFNB2 True Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP0,SFNB2_SFNB_FP0,SFNB2_SFNB_FP0,SFNB2 False Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC0,SFNB2_SFNB_RTC0,SFNB2_SFNB_RTC0,SFNB2 Median Response Time for Correct 0-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP1,SFNB2_SFNB_TP1,SFNB2_SFNB_TP1,SFNB2 True Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP1,SFNB2_SFNB_FP1,SFNB2_SFNB_FP1,SFNB2 False Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC1,SFNB2_SFNB_RTC1,SFNB2_SFNB_RTC1,SFNB2 Median Response Time for Correct 1-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP2,SFNB2_SFNB_TP2,SFNB2_SFNB_TP2,SFNB2 True Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP2,SFNB2_SFNB_FP2,SFNB2_SFNB_FP2,SFNB2 False Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN0,SFNB2_SFNB_TN0,SFNB2_SFNB_TN0,SFNB2 True Negative Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN1,SFNB2_SFNB_TN1,SFNB2_SFNB_TN1,SFNB2 True Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN2,SFNB2_SFNB_TN2,SFNB2_SFNB_TN2,SFNB2 True Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FN1,SFNB2_SFNB_FN1,SFNB2_SFNB_FN1,SFNB2 False Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FN2,SFNB2_SFNB_FN2,SFNB2_SFNB_FN2,SFNB2 False Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC2,SFNB2_SFNB_RTC2,SFNB2_SFNB_RTC2,SFNB2 Median Response Time for Correct 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MCR,SFNB2_SFNB_MCR,SFNB2_SFNB_MCR,SFNB2 True Positive Reponses for 1-Back and 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MRTC,SFNB2_SFNB_MRTC,SFNB2_SFNB_MRTC,SFNB2 Mean of Median RT for True Positive Responses for 1-Back and for 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MRT,SFNB2_SFNB_MRT,SFNB2_SFNB_MRT,SFNB2 Median Response Time for All Responses (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MEFF,SFNB2_SFNB_MEFF,SFNB2_SFNB_MEFF,SFNB2 Efficiency = SFNB_MCR/log(SFNB_MRTC),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MSEN,SFNB2_SFNB_MSEN,,SFNB2 Sensitivity = (SFNB_TP1 + SFNB_TP2)/(SFNB_TP1 + SFNB_TP2 +SFNB_FN1 + SFNB_FN2),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MSPEC,SFNB2_SFNB_MSPEC,,SFNB2 Specificity = (SFNB_TN1 + SFNB_TN2)/(SFNB_TN1 + SFNB_TN2 +SFNB_FP1 + SFNB_FP2),Short Fractal-N-Back- 2 Back Version
+ER40_D_ScorVers,ER40_D_ScorVers,ER40D,Current Programming Version of the Scoring Code,Emotion Recognition Task- Form D- 40 items 
+ER40_D_status,ER40_D_status,ER40D_status,ER40 completion status,Emotion Recognition Task- Form D- 40 items 
+ER40_D_valid_code,ER40_D_valid_code,ER40D_valid_code,ER40 valid code,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CR,ER40_D_ER40D_CR,ER40D_ER40_CR,ER40 Correct Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_RTCR,ER40_D_ER40D_RTCR,ER40D_ER40_CRT,ER40 Correct Responses Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_RT,ER40_D_ER40D_RT,,Median Response Time for All Trials (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FC,ER40_D_ER40D_FC,ER40D_ER40_FC,ER40 Correct Female Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MC,ER40_D_ER40D_MC,ER40D_ER40_MC,ER40 Correct Male Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FCRT,ER40_D_ER40D_FCRT,ER40D_ER40FCRT,ER40 Correct Female Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MCRT,ER40_D_ER40D_MCRT,ER40D_ER40MCRT,ER40 Correct Male Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_ANG,ER40_D_ER40D_ANG,ER40D_ER40ANG,ER40 Correct Anger Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FEAR,ER40_D_ER40D_FEAR,ER40D_ER40FEAR,ER40 Correct Fear Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_HAP,ER40_D_ER40D_HAP,ER40D_ER40HAP,ER40 Correct Happy Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_NOE,ER40_D_ER40D_NOE,ER40D_ER40NOE,ER40 Correct No Emotion Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_SAD,ER40_D_ER40D_SAD,ER40D_ER40SAD,ER40 Correct Sad Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FACR,ER40_D_ER40D_FACR,ER40D_ER40FACR,ER40 Correct Anger Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFCR,ER40_D_ER40D_FFCR,ER40D_ER40FFCR,ER40 Correct Fear Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHCR,ER40_D_ER40D_FHCR,ER40D_ER40FHCR,ER40 Correct Happy Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNCR,ER40_D_ER40D_FNCR,ER40D_ER40FNCR,ER40 Correct No Emotion Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSCR,ER40_D_ER40D_FSCR,ER40D_ER40FSCR,ER40 Correct Sad Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MACR,ER40_D_ER40D_MACR,ER40D_ER40MACR,ER40 Correct Anger Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFCR,ER40_D_ER40D_MFCR,ER40D_ER40MFCR,ER40 Correct Fear Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHCR,ER40_D_ER40D_MHCR,ER40D_ER40MHCR,ER40 Correct Happy Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNCR,ER40_D_ER40D_MNCR,ER40D_ER40MNCR,ER40 Correct No Emotion Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSCR,ER40_D_ER40D_MSCR,ER40D_ER40MSCR,ER40 Correct Sad Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPA,ER40_D_ER40D_FPA,ER40D_ER40_FPA,ER40 False Positive Anger Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPF,ER40_D_ER40D_FPF,ER40D_ER40_FPF,ER40 False Positive Fear Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPH,ER40_D_ER40D_FPH,ER40D_ER40_FPH,ER40 False Positive Happy Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPN,ER40_D_ER40D_FPN,ER40D_ER40_FPN,ER40 False Positive No Emotion Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPS,ER40_D_ER40D_FPS,ER40D_ER40_FPS,ER40 False Positive Sad Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_ANGRT,ER40_D_ER40D_ANGRT,ER40D_ER40ANGRT,Median Response Time for ER40 Correct Anger Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FEARRT,ER40_D_ER40D_FEARRT,ER40D_ER40FEARRT,Median Response Time for ER40 Correct Fear Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_HAPRT,ER40_D_ER40D_HAPRT,ER40D_ER40HAPRT,Median Response Time for ER40 Correct Happy Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_NOERT,ER40_D_ER40D_NOERT,ER40D_ER40NOERT,Median Response Time for ER40 Correct No Emotion Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_SADRT,ER40_D_ER40D_SADRT,ER40D_ER40SADRT,Median Response Time for ER40 Correct Sad Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FART,ER40_D_ER40D_FART,ER40D_ER40FART,Median Response Time for ER40 Correct Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFRT,ER40_D_ER40D_FFRT,ER40D_ER40FFRT,Median Response Time for ER40 Correct Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHRT,ER40_D_ER40D_FHRT,ER40D_ER40FHRT,Median Response Time for ER40 Correct Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNRT,ER40_D_ER40D_FNRT,ER40D_ER40FNRT,Median Response Time for ER40 Correct No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSRT,ER40_D_ER40D_FSRT,ER40D_ER40FSRT,Median Response Time for ER40 Correct Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MART,ER40_D_ER40D_MART,ER40D_ER40MART,Median Response Time for ER40 Correct Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFRT,ER40_D_ER40D_MFRT,ER40D_ER40MFRT,Median Response Time for ER40 Correct Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHRT,ER40_D_ER40D_MHRT,ER40D_ER40MHRT,Median Response Time for ER40 Correct Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNRT,ER40_D_ER40D_MNRT,ER40D_ER40MNRT,Median Response Time for ER40 Correct No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSRT,ER40_D_ER40D_MSRT,ER40D_ER40MSRT,Median Response Time for ER40 Correct Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FAERT,ER40_D_ER40D_FAERT,ER40D_ER40FAERT,Median Response Time for ER40 Incorrect Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFERT,ER40_D_ER40D_FFERT,ER40D_ER40FFERT,Median Response Time for ER40 Incorrect Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHERT,ER40_D_ER40D_FHERT,ER40D_ER40FHERT,Median Response Time for ER40 Incorrect Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNERT,ER40_D_ER40D_FNERT,ER40D_ER40FNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSERT,ER40_D_ER40D_FSERT,ER40D_ER40FSERT,Median Response Time for ER40 Incorrect Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MAERT,ER40_D_ER40D_MAERT,ER40D_ER40MAERT,Median Response Time for ER40 Incorrect Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFERT,ER40_D_ER40D_MFERT,ER40D_ER40MFERT,Median Response Time for ER40 Incorrect Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHERT,ER40_D_ER40D_MHERT,ER40D_ER40MHERT,Median Response Time for ER40 Incorrect Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNERT,ER40_D_ER40D_MNERT,ER40D_ER40MNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSERT,ER40_D_ER40D_MSERT,ER40D_ER40MSERT,Median Response Time for ER40 Incorrect Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPART,ER40_D_ER40D_FPART,ER40D_ER40_FPART,Median Response Time for ER40 False Positive Anger Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPFRT,ER40_D_ER40D_FPFRT,ER40D_ER40_FPFRT,Median Response Time for ER40 False Positive Fear Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPHRT,ER40_D_ER40D_FPHRT,ER40D_ER40_FPHRT,Median Response Time for ER40 False Positive Happy Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPNRT,ER40_D_ER40D_FPNRT,ER40D_ER40_FPNRT,Median Response Time for ER40 False Positive No Emotion Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPSRT,ER40_D_ER40D_FPSRT,ER40D_ER40_FPSRT,Median Response Time for ER40 False Positive Sad Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CACR,ER40_D_ER40D_CACR,ER40D_ER40CACR,ER40 Correct Identifications of Caucasian faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_AACR,ER40_D_ER40D_AACR,ER40D_ER40AACR,ER40 Correct Identifications of African American faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_OTHCR,ER40_D_ER40D_OTHCR,ER40D_ER40OTHCR,ER40 Correct Identifications of Other Race faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CACRT,ER40_D_ER40D_CACRT,ER40D_ER40CACRT,ER40 Median Response Time for Correct Identifications of Caucasian faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_AACRT,ER40_D_ER40D_AACRT,ER40D_ER40AACRT,ER40 Median Response Time for Correct Identifications of African American faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_OTHCRT,ER40_D_ER40D_OTHCRT,ER40D_ER40OTHCRT,ER40 Median Response Time for Correct Identifications of Other Race faces (ms),Emotion Recognition Task- Form D- 40 items 
+MEDF36_A_ScorVers,MEDF36_A_ScorVers,MEDF36,Current Programming Version of the Scoring Code,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_status,MEDF36_A_status,MEDF36_status,MEDF36 completion status,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_valid_code,MEDF36_A_valid_code,MEDF36_valid_code,MEDF36 valid code,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CR,MEDF36_A_MEDF36A_CR,MEDF36_MEDF36_A,Total Correct Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PC,MEDF36_A_MEDF36A_PC,,Percent Correct Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_RTCR,MEDF36_A_MEDF36A_RTCR,MEDF36_MEDF36_T,Median Response Time for All Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ER,MEDF36_A_MEDF36A_ER,,Total Incorrect Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_RTER,MEDF36_A_MEDF36A_RTER,,Median Response Time for Incorrect Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_CR,MEDF36_A_MEDF36A_ANG_CR,MEDF36_MEDF36_ANG_CR,Correct Responses for Measured Emodiff Angry Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_RTCR,MEDF36_A_MEDF36A_ANG_RTCR,MEDF36_MEDF36_ANG_RTCR,Median Response Time for Correct Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_ER,MEDF36_A_MEDF36A_ANG_ER,,Total Incorrect Anger Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_RTER,MEDF36_A_MEDF36A_ANG_RTER,MEDF36_MEDF36_ANG_RTER,Median Response Time for Incorrect Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CA_CR,MEDF36_A_MEDF36A_CA_CR,,Total Correct Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CA_RTCR,MEDF36_A_MEDF36A_CA_RTCR,,Median Response Time for Correct Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT10_CR,MEDF36_A_MEDF36A_PCT10_CR,,Total Correct 10 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT10_RTCR,MEDF36_A_MEDF36A_PCT10_RTCR,,Median Response Time for Correct 10 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT20_CR,MEDF36_A_MEDF36A_PCT20_CR,,Total Correct 20 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT20_RTCR,MEDF36_A_MEDF36A_PCT20_RTCR,,Median Response Time for Correct 20 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT30_CR,MEDF36_A_MEDF36A_PCT30_CR,,Total Correct 30 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT30_RTCR,MEDF36_A_MEDF36A_PCT30_RTCR,,Median Response Time for Correct 30 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT40_CR,MEDF36_A_MEDF36A_PCT40_CR,,Total Correct 40 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT40_RTCR,MEDF36_A_MEDF36A_PCT40_RTCR,,Median Response Time for Correct 40 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT50_CR,MEDF36_A_MEDF36A_PCT50_CR,,Total Correct 50 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT50_RTCR,MEDF36_A_MEDF36A_PCT50_RTCR,,Median Response Time for Correct 50 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT60_CR,MEDF36_A_MEDF36A_PCT60_CR,,Total Correct 60 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT60_RTCR,MEDF36_A_MEDF36A_PCT60_RTCR,,Median Response Time for Correct 60 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_CR,MEDF36_A_MEDF36A_FEAR_CR,MEDF36_MEDF36_FEAR_CR,Correct Responses for Measured Emodiff Fear Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_RTCR,MEDF36_A_MEDF36A_FEAR_RTCR,MEDF36_MEDF36_FEAR_RTCR,Median Response Time for Correct Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_ER,MEDF36_A_MEDF36A_FEAR_ER,,Total Incorrect Fear Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_RTER,MEDF36_A_MEDF36A_FEAR_RTER,MEDF36_MEDF36_FEAR_RTER,Median Response Time for Incorrect Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEMALE_CR,MEDF36_A_MEDF36A_FEMALE_CR,,Total Correct Female Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEMALE_RTCR,MEDF36_A_MEDF36A_FEMALE_RTCR,,Median Response Time for Correct Female Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_CR,MEDF36_A_MEDF36A_HAP_CR,MEDF36_MEDF36_HAP_CR,Correct Responses for Measured Emodiff Happy Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_RTCR,MEDF36_A_MEDF36A_HAP_RTCR,MEDF36_MEDF36_HAP_RTCR,Median Response Time for Correct Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_ER,MEDF36_A_MEDF36A_HAP_ER,,Total Incorrect Happy Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_RTER,MEDF36_A_MEDF36A_HAP_RTER,MEDF36_MEDF36_HAP_RTER,Median Response Time for Incorrect Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_MALE_CR,MEDF36_A_MEDF36A_MALE_CR,,Total Correct Male Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_MALE_RTCR,MEDF36_A_MEDF36A_MALE_RTCR,,Median Response Time for Correct Male Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NONCA_CR,MEDF36_A_MEDF36A_NONCA_CR,,Total Correct Non-Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NONCA_RTCR,MEDF36_A_MEDF36A_NONCA_RTCR,,Median Response Time for Correct Non-Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NS_CR,MEDF36_A_MEDF36A_NS_CR,MEDF36_MEDF36_NS_CR,"Total Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NS_RTCR,MEDF36_A_MEDF36A_NS_RTCR,MEDF36_MEDF36_NS_RTCR,"Median Response Time for Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_CR,MEDF36_A_MEDF36A_SAD_CR,MEDF36_MEDF36_SAD_CR,Correct Responses for Measured Emodiff Sad Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_RTCR,MEDF36_A_MEDF36A_SAD_RTCR,MEDF36_MEDF36_SAD_RTCR,Median Response Time for Correct Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_ER,MEDF36_A_MEDF36A_SAD_ER,,Total Incorrect Sad Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_RTER,MEDF36_A_MEDF36A_SAD_RTER,MEDF36_MEDF36_SAD_RTER,Median Response Time for Incorrect Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_CR,MEDF36_A_MEDF36A_SAME_CR,MEDF36_MEDF36_SAME_CR,Correct Responses for Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_RTCR,Median Response Time for Correct Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items

--- a/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
+++ b/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
@@ -1,0 +1,1161 @@
+﻿NCANDA Survey Variable Name,EVIONI2 Variable Name,Variable Description,Test Source
+test_sessions_datasetid,test_sessions_datasetid,Unique Number for that CNB,Test Sessions
+test_sessions_siteid,test_sessions_siteid,Site ID battery was administered to,Test Sessions
+test_sessions_famid,test_sessions_famid,Family ID battery was administered to,Test Sessions
+test_sessions_subid,test_sessions_subid,Subject ID battery was administered to,Test Sessions
+test_sessions_bblid,test_sessions_bblid,BBLID battery was administered to,Test Sessions
+test_sessions_v_battery,test_sessions_battery,Battery Name,Test Sessions
+test_sessions_v_age,test_sessions_age,Age of participant,Test Sessions
+test_sessions_v_gender,test_sessions_gender,Gender of participant,Test Sessions
+test_sessions_v_dotest,test_sessions_dotest,Date of CNB,Test Sessions
+test_sessions_v_dob,test_sessions_dob,Date of Birth of participant,Test Sessions
+test_sessions_v_handedness,test_sessions_handedness,Handedness of participant,Test Sessions
+test_sessions_v_education,test_sessions_education,Highest Level of Education of participant,Test Sessions
+test_sessions_v_feducation,test_sessions_feducation,Highest Level of Education of participant's father,Test Sessions
+test_sessions_v_meducation,test_sessions_meducation,Highest Level of Education of participant's mother,Test Sessions
+test_sessions_v_admin_comments,test_sessions_admin_comments,Administrator Comments,Test Sessions
+test_sessions_v_valid_code,test_sessions_valid_code,Validation Code Assigned,Test Sessions
+CPF_ScorVers,CPF_Scorvers,Current Programming Version of the Scoring Code,Penn Facial Memory Test
+CPF_status,CPF_status,Status Code Assigned to CPF,Penn Facial Memory Test
+CPF_valid_code,CPF_valid_code,Valid Code Assigned to CPF,Penn Facial Memory Test
+CPF_CPFTP,CPF_CPFTP,CPF True Positives,Penn Facial Memory Test
+CPF_CPFTN,CPF_CPFTN,CPF True Negatives,Penn Facial Memory Test
+CPF_CPFFP,CPF_CPFFP,CPF False Positives,Penn Facial Memory Test
+CPF_CPFFN,CPF_CPFFN,CPF False Negatives,Penn Facial Memory Test
+CPF_CPFTPRT,CPF_CPFTPRT,CPF True Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_CPFTNRT,CPF_CPFTNRT,CPF True Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_CPFFPRT,CPF_CPFFPRT,CPF False Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_CPFFNRT,CPF_CPFFNRT,CPF False Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_IFAC_TOT,CPF_IFAC_TOT,CPF Total Correct Responses,Penn Facial Memory Test
+CPF_IFAC_RTC,CPF_IFAC_RTC,CPF Median Total Correct Response Time (ms),Penn Facial Memory Test
+CPF_q1_resp,CPF_q1_resp,Response for trial 1,Penn Facial Memory Test
+CPF_q1_ttr,CPF_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test
+CPF_q1_corr,CPF_q1_corr,Response correct for trial 1,Penn Facial Memory Test
+CPF_q2_resp,CPF_q2_resp,Response for trial 2,Penn Facial Memory Test
+CPF_q2_ttr,CPF_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test
+CPF_q2_corr,CPF_q2_corr,Response correct for trial 2,Penn Facial Memory Test
+CPF_q3_resp,CPF_q3_resp,Response for trial 3,Penn Facial Memory Test
+CPF_q3_ttr,CPF_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test
+CPF_q3_corr,CPF_q3_corr,Response correct for trial 3,Penn Facial Memory Test
+CPF_q4_resp,CPF_q4_resp,Response for trial 4,Penn Facial Memory Test
+CPF_q4_ttr,CPF_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test
+CPF_q4_corr,CPF_q4_corr,Response correct for trial 4,Penn Facial Memory Test
+CPF_q5_resp,CPF_q5_resp,Response for trial 5,Penn Facial Memory Test
+CPF_q5_ttr,CPF_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test
+CPF_q5_corr,CPF_q5_corr,Response correct for trial 5,Penn Facial Memory Test
+CPF_q6_resp,CPF_q6_resp,Response for trial 6,Penn Facial Memory Test
+CPF_q6_ttr,CPF_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test
+CPF_q6_corr,CPF_q6_corr,Response correct for trial 6,Penn Facial Memory Test
+CPF_q7_resp,CPF_q7_resp,Response for trial 7,Penn Facial Memory Test
+CPF_q7_ttr,CPF_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test
+CPF_q7_corr,CPF_q7_corr,Response correct for trial 7,Penn Facial Memory Test
+CPF_q8_resp,CPF_q8_resp,Response for trial 8,Penn Facial Memory Test
+CPF_q8_ttr,CPF_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test
+CPF_q8_corr,CPF_q8_corr,Response correct for trial 8,Penn Facial Memory Test
+CPF_q9_resp,CPF_q9_resp,Response for trial 9,Penn Facial Memory Test
+CPF_q9_ttr,CPF_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test
+CPF_q9_corr,CPF_q9_corr,Response correct for trial 9,Penn Facial Memory Test
+CPF_q10_resp,CPF_q10_resp,Response for trial 10,Penn Facial Memory Test
+CPF_q10_ttr,CPF_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test
+CPF_q10_corr,CPF_q10_corr,Response correct for trial 10,Penn Facial Memory Test
+CPF_q11_resp,CPF_q11_resp,Response for trial 11,Penn Facial Memory Test
+CPF_q11_ttr,CPF_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test
+CPF_q11_corr,CPF_q11_corr,Response correct for trial 11,Penn Facial Memory Test
+CPF_q12_resp,CPF_q12_resp,Response for trial 12,Penn Facial Memory Test
+CPF_q12_ttr,CPF_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test
+CPF_q12_corr,CPF_q12_corr,Response correct for trial 12,Penn Facial Memory Test
+CPF_q13_resp,CPF_q13_resp,Response for trial 13,Penn Facial Memory Test
+CPF_q13_ttr,CPF_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test
+CPF_q13_corr,CPF_q13_corr,Response correct for trial 13,Penn Facial Memory Test
+CPF_q14_resp,CPF_q14_resp,Response for trial 14,Penn Facial Memory Test
+CPF_q14_ttr,CPF_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test
+CPF_q14_corr,CPF_q14_corr,Response correct for trial 14,Penn Facial Memory Test
+CPF_q15_resp,CPF_q15_resp,Response for trial 15,Penn Facial Memory Test
+CPF_q15_ttr,CPF_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test
+CPF_q15_corr,CPF_q15_corr,Response correct for trial 15,Penn Facial Memory Test
+CPF_q16_resp,CPF_q16_resp,Response for trial 16,Penn Facial Memory Test
+CPF_q16_ttr,CPF_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test
+CPF_q16_corr,CPF_q16_corr,Response correct for trial 16,Penn Facial Memory Test
+CPF_q17_resp,CPF_q17_resp,Response for trial 17,Penn Facial Memory Test
+CPF_q17_ttr,CPF_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test
+CPF_q17_corr,CPF_q17_corr,Response correct for trial 17,Penn Facial Memory Test
+CPF_q18_resp,CPF_q18_resp,Response for trial 18,Penn Facial Memory Test
+CPF_q18_ttr,CPF_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test
+CPF_q18_corr,CPF_q18_corr,Response correct for trial 18,Penn Facial Memory Test
+CPF_q19_resp,CPF_q19_resp,Response for trial 19,Penn Facial Memory Test
+CPF_q19_ttr,CPF_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test
+CPF_q19_corr,CPF_q19_corr,Response correct for trial 19,Penn Facial Memory Test
+CPF_q20_resp,CPF_q20_resp,Response for trial 20,Penn Facial Memory Test
+CPF_q20_ttr,CPF_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test
+CPF_q20_corr,CPF_q20_corr,Response correct for trial 20,Penn Facial Memory Test
+CPF_q21_resp,CPF_q21_resp,Response for trial 21,Penn Facial Memory Test
+CPF_q21_ttr,CPF_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test
+CPF_q21_corr,CPF_q21_corr,Response correct for trial 21,Penn Facial Memory Test
+CPF_q22_resp,CPF_q22_resp,Response for trial 22,Penn Facial Memory Test
+CPF_q22_ttr,CPF_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test
+CPF_q22_corr,CPF_q22_corr,Response correct for trial 22,Penn Facial Memory Test
+CPF_q23_resp,CPF_q23_resp,Response for trial 23,Penn Facial Memory Test
+CPF_q23_ttr,CPF_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test
+CPF_q23_corr,CPF_q23_corr,Response correct for trial 23,Penn Facial Memory Test
+CPF_q24_resp,CPF_q24_resp,Response for trial 24,Penn Facial Memory Test
+CPF_q24_ttr,CPF_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test
+CPF_q24_corr,CPF_q24_corr,Response correct for trial 24,Penn Facial Memory Test
+CPF_q25_resp,CPF_q25_resp,Response for trial 25,Penn Facial Memory Test
+CPF_q25_ttr,CPF_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test
+CPF_q25_corr,CPF_q25_corr,Response correct for trial 25,Penn Facial Memory Test
+CPF_q26_resp,CPF_q26_resp,Response for trial 26,Penn Facial Memory Test
+CPF_q26_ttr,CPF_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test
+CPF_q26_corr,CPF_q26_corr,Response correct for trial 26,Penn Facial Memory Test
+CPF_q27_resp,CPF_q27_resp,Response for trial 27,Penn Facial Memory Test
+CPF_q27_ttr,CPF_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test
+CPF_q27_corr,CPF_q27_corr,Response correct for trial 27,Penn Facial Memory Test
+CPF_q28_resp,CPF_q28_resp,Response for trial 28,Penn Facial Memory Test
+CPF_q28_ttr,CPF_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test
+CPF_q28_corr,CPF_q28_corr,Response correct for trial 28,Penn Facial Memory Test
+CPF_q29_resp,CPF_q29_resp,Response for trial 29,Penn Facial Memory Test
+CPF_q29_ttr,CPF_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test
+CPF_q29_corr,CPF_q29_corr,Response correct for trial 29,Penn Facial Memory Test
+CPF_q30_resp,CPF_q30_resp,Response for trial 30,Penn Facial Memory Test
+CPF_q30_ttr,CPF_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test
+CPF_q30_corr,CPF_q30_corr,Response correct for trial 30,Penn Facial Memory Test
+CPF_q31_resp,CPF_q31_resp,Response for trial 31,Penn Facial Memory Test
+CPF_q31_ttr,CPF_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test
+CPF_q31_corr,CPF_q31_corr,Response correct for trial 31,Penn Facial Memory Test
+CPF_q32_resp,CPF_q32_resp,Response for trial 32,Penn Facial Memory Test
+CPF_q32_ttr,CPF_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test
+CPF_q32_corr,CPF_q32_corr,Response correct for trial 32,Penn Facial Memory Test
+CPF_q33_resp,CPF_q33_resp,Response for trial 33,Penn Facial Memory Test
+CPF_q33_ttr,CPF_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test
+CPF_q33_corr,CPF_q33_corr,Response correct for trial 33,Penn Facial Memory Test
+CPF_q34_resp,CPF_q34_resp,Response for trial 34,Penn Facial Memory Test
+CPF_q34_ttr,CPF_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test
+CPF_q34_corr,CPF_q34_corr,Response correct for trial 34,Penn Facial Memory Test
+CPF_q35_resp,CPF_q35_resp,Response for trial 35,Penn Facial Memory Test
+CPF_q35_ttr,CPF_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test
+CPF_q35_corr,CPF_q35_corr,Response correct for trial 35,Penn Facial Memory Test
+CPF_q36_resp,CPF_q36_resp,Response for trial 36,Penn Facial Memory Test
+CPF_q36_ttr,CPF_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test
+CPF_q36_corr,CPF_q36_corr,Response correct for trial 36,Penn Facial Memory Test
+CPF_q37_resp,CPF_q37_resp,Response for trial 37,Penn Facial Memory Test
+CPF_q37_ttr,CPF_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test
+CPF_q37_corr,CPF_q37_corr,Response correct for trial 37,Penn Facial Memory Test
+CPF_q38_resp,CPF_q38_resp,Response for trial 38,Penn Facial Memory Test
+CPF_q38_ttr,CPF_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test
+CPF_q38_corr,CPF_q38_corr,Response correct for trial 38,Penn Facial Memory Test
+CPF_q39_resp,CPF_q39_resp,Response for trial 39,Penn Facial Memory Test
+CPF_q39_ttr,CPF_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test
+CPF_q39_corr,CPF_q39_corr,Response correct for trial 39,Penn Facial Memory Test
+CPF_q40_resp,CPF_q40_resp,Response for trial 40,Penn Facial Memory Test
+CPF_q40_ttr,CPF_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test
+CPF_q40_corr,CPF_q40_corr,Response correct for trial 40,Penn Facial Memory Test
+CPFD_A_ScorVers,CPFD_Scorvers,Current Programming Version of the Scoring Code,Penn Facial Memory Test - Delayed Version
+CPFD_A_status,CPFD_status,Status Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
+CPFD_A_valid_code,CPFD_valid_code,Valid Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TP,CPFD_CPFDTP,CPFD True Positives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TN,CPFD_CPFDTN,CPFD True Negatives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FP,CPFD_CPFDFP,CPFD False Positives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FN,CPFD_CPFDFN,CPFD False Negatives,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TPRT,CPFD_CPFDTPRT,CPFD True Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TNRT,CPFD_CPFDTNRT,CPFD True Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FPRT,CPFD_CPFDFPRT,CPFD False Positives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_FNRT,CPFD_CPFDFNRT,CPFD False Negatives Median Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_CR,CPFD_DFAC_TOT,CPFD Total Correct Responses,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RTCR,CPFD_DFAC_RTC,CPFD Median Total Correct Response Time (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_ER,,Total Incorrect Responses,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_RT,,Median Response Time for All Responses (ms),Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_RESP,CPFD_q1_resp,Response for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_TTR,CPFD_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000001_CORR,CPFD_q1_corr,Response correct for trial 1,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_RESP,CPFD_q2_resp,Response for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_TTR,CPFD_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000002_CORR,CPFD_q2_corr,Response correct for trial 2,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_RESP,CPFD_q3_resp,Response for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_TTR,CPFD_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000003_CORR,CPFD_q3_corr,Response correct for trial 3,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_RESP,CPFD_q4_resp,Response for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_TTR,CPFD_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000004_CORR,CPFD_q4_corr,Response correct for trial 4,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_RESP,CPFD_q5_resp,Response for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_TTR,CPFD_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000005_CORR,CPFD_q5_corr,Response correct for trial 5,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_RESP,CPFD_q6_resp,Response for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_TTR,CPFD_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000006_CORR,CPFD_q6_corr,Response correct for trial 6,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_RESP,CPFD_q7_resp,Response for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_TTR,CPFD_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000007_CORR,CPFD_q7_corr,Response correct for trial 7,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_RESP,CPFD_q8_resp,Response for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_TTR,CPFD_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000008_CORR,CPFD_q8_corr,Response correct for trial 8,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_RESP,CPFD_q9_resp,Response for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_TTR,CPFD_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000009_CORR,CPFD_q9_corr,Response correct for trial 9,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_RESP,CPFD_q10_resp,Response for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_TTR,CPFD_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000010_CORR,CPFD_q10_corr,Response correct for trial 10,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_RESP,CPFD_q11_resp,Response for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_TTR,CPFD_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000011_CORR,CPFD_q11_corr,Response correct for trial 11,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_RESP,CPFD_q12_resp,Response for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_TTR,CPFD_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000012_CORR,CPFD_q12_corr,Response correct for trial 12,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_RESP,CPFD_q13_resp,Response for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_TTR,CPFD_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000013_CORR,CPFD_q13_corr,Response correct for trial 13,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_RESP,CPFD_q14_resp,Response for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_TTR,CPFD_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000014_CORR,CPFD_q14_corr,Response correct for trial 14,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_RESP,CPFD_q15_resp,Response for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_TTR,CPFD_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000015_CORR,CPFD_q15_corr,Response correct for trial 15,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_RESP,CPFD_q16_resp,Response for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_TTR,CPFD_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000016_CORR,CPFD_q16_corr,Response correct for trial 16,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_RESP,CPFD_q17_resp,Response for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_TTR,CPFD_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000017_CORR,CPFD_q17_corr,Response correct for trial 17,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_RESP,CPFD_q18_resp,Response for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_TTR,CPFD_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000018_CORR,CPFD_q18_corr,Response correct for trial 18,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_RESP,CPFD_q19_resp,Response for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_TTR,CPFD_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000019_CORR,CPFD_q19_corr,Response correct for trial 19,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_RESP,CPFD_q20_resp,Response for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_TTR,CPFD_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000020_CORR,CPFD_q20_corr,Response correct for trial 20,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_RESP,CPFD_q21_resp,Response for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_TTR,CPFD_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000021_CORR,CPFD_q21_corr,Response correct for trial 21,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_RESP,CPFD_q22_resp,Response for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_TTR,CPFD_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000022_CORR,CPFD_q22_corr,Response correct for trial 22,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_RESP,CPFD_q23_resp,Response for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_TTR,CPFD_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000023_CORR,CPFD_q23_corr,Response correct for trial 23,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_RESP,CPFD_q24_resp,Response for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_TTR,CPFD_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000024_CORR,CPFD_q24_corr,Response correct for trial 24,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_RESP,CPFD_q25_resp,Response for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_TTR,CPFD_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000025_CORR,CPFD_q25_corr,Response correct for trial 25,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_RESP,CPFD_q26_resp,Response for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_TTR,CPFD_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000026_CORR,CPFD_q26_corr,Response correct for trial 26,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_RESP,CPFD_q27_resp,Response for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_TTR,CPFD_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000027_CORR,CPFD_q27_corr,Response correct for trial 27,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_RESP,CPFD_q28_resp,Response for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_TTR,CPFD_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000028_CORR,CPFD_q28_corr,Response correct for trial 28,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_RESP,CPFD_q29_resp,Response for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_TTR,CPFD_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000029_CORR,CPFD_q29_corr,Response correct for trial 29,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_RESP,CPFD_q30_resp,Response for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_TTR,CPFD_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000030_CORR,CPFD_q30_corr,Response correct for trial 30,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_RESP,CPFD_q31_resp,Response for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_TTR,CPFD_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000031_CORR,CPFD_q31_corr,Response correct for trial 31,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_RESP,CPFD_q32_resp,Response for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_TTR,CPFD_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000032_CORR,CPFD_q32_corr,Response correct for trial 32,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_RESP,CPFD_q33_resp,Response for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_TTR,CPFD_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000033_CORR,CPFD_q33_corr,Response correct for trial 33,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_RESP,CPFD_q34_resp,Response for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_TTR,CPFD_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000034_CORR,CPFD_q34_corr,Response correct for trial 34,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_RESP,CPFD_q35_resp,Response for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_TTR,CPFD_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000035_CORR,CPFD_q35_corr,Response correct for trial 35,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_RESP,CPFD_q36_resp,Response for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_TTR,CPFD_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000036_CORR,CPFD_q36_corr,Response correct for trial 36,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_RESP,CPFD_q37_resp,Response for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_TTR,CPFD_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000037_CORR,CPFD_q37_corr,Response correct for trial 37,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_RESP,CPFD_q38_resp,Response for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_TTR,CPFD_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000038_CORR,CPFD_q38_corr,Response correct for trial 38,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_RESP,CPFD_q39_resp,Response for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_TTR,CPFD_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000039_CORR,CPFD_q39_corr,Response correct for trial 39,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_RESP,CPFD_q40_resp,Response for trial 40,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_TTR,CPFD_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
+CPFD_A_CPFD_TRIAL000040_CORR,CPFD_q40_corr,Response correct for trial 40,Penn Facial Memory Test - Delayed Version
+CPW_ScorVers,CPW_Scorvers,Current Programming Version of the Scoring Code,Penn Word Memory Test
+CPW_status,CPW_status,Status Code Assigned to CPW,Penn Word Memory Test
+CPW_valid_code,CPW_valid_code,Valid Code Assigned to CPW,Penn Word Memory Test
+CPW_CPWTP,CPW_CPWTP,CPW True Positive Responses,Penn Word Memory Test
+CPW_CPWTN,CPW_CPWTN,CPW True Negative Responses,Penn Word Memory Test
+CPW_CPWFP,CPW_CPWFP,CPW False Positive Responses,Penn Word Memory Test
+CPW_CPWFN,CPW_CPWFN,CPW False Negative Responses,Penn Word Memory Test
+CPW_CPWTPRT,CPW_CPWTPRT,Median Response Time for CPW True Positive Responses (ms),Penn Word Memory Test
+CPW_CPWTNRT,CPW_CPWTNRT,Median Response Time for CPW True Negative Responses (ms),Penn Word Memory Test
+CPW_CPWFPRT,CPW_CPWFPRT,Median Response Time for CPW False Positive Responses (ms),Penn Word Memory Test
+CPW_CPWFNRT,CPW_CPWFNRT,Median Response Time for CPW False Negative Responses (ms),Penn Word Memory Test
+CPW_IWRD_TOT,CPW_IWRD_TOT,CPW Total Correct Responses,Penn Word Memory Test
+CPW_IWRD_RTC,CPW_IWRD_RTC,Median Response Time for CPW Total Correct Responses (ms),Penn Word Memory Test
+CPW_q1_resp,CPW_q1_resp,Response for trial 1,Penn Word Memory Test
+CPW_q1_ttr,CPW_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test
+CPW_q1_corr,CPW_q1_corr,Response correct for trial 1,Penn Word Memory Test
+CPW_q2_resp,CPW_q2_resp,Response for trial 2,Penn Word Memory Test
+CPW_q2_ttr,CPW_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test
+CPW_q2_corr,CPW_q2_corr,Response correct for trial 2,Penn Word Memory Test
+CPW_q3_resp,CPW_q3_resp,Response for trial 3,Penn Word Memory Test
+CPW_q3_ttr,CPW_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test
+CPW_q3_corr,CPW_q3_corr,Response correct for trial 3,Penn Word Memory Test
+CPW_q4_resp,CPW_q4_resp,Response for trial 4,Penn Word Memory Test
+CPW_q4_ttr,CPW_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test
+CPW_q4_corr,CPW_q4_corr,Response correct for trial 4,Penn Word Memory Test
+CPW_q5_resp,CPW_q5_resp,Response for trial 5,Penn Word Memory Test
+CPW_q5_ttr,CPW_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test
+CPW_q5_corr,CPW_q5_corr,Response correct for trial 5,Penn Word Memory Test
+CPW_q6_resp,CPW_q6_resp,Response for trial 6,Penn Word Memory Test
+CPW_q6_ttr,CPW_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test
+CPW_q6_corr,CPW_q6_corr,Response correct for trial 6,Penn Word Memory Test
+CPW_q7_resp,CPW_q7_resp,Response for trial 7,Penn Word Memory Test
+CPW_q7_ttr,CPW_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test
+CPW_q7_corr,CPW_q7_corr,Response correct for trial 7,Penn Word Memory Test
+CPW_q8_resp,CPW_q8_resp,Response for trial 8,Penn Word Memory Test
+CPW_q8_ttr,CPW_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test
+CPW_q8_corr,CPW_q8_corr,Response correct for trial 8,Penn Word Memory Test
+CPW_q9_resp,CPW_q9_resp,Response for trial 9,Penn Word Memory Test
+CPW_q9_ttr,CPW_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test
+CPW_q9_corr,CPW_q9_corr,Response correct for trial 9,Penn Word Memory Test
+CPW_q10_resp,CPW_q10_resp,Response for trial 10,Penn Word Memory Test
+CPW_q10_ttr,CPW_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test
+CPW_q10_corr,CPW_q10_corr,Response correct for trial 10,Penn Word Memory Test
+CPW_q11_resp,CPW_q11_resp,Response for trial 11,Penn Word Memory Test
+CPW_q11_ttr,CPW_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test
+CPW_q11_corr,CPW_q11_corr,Response correct for trial 11,Penn Word Memory Test
+CPW_q12_resp,CPW_q12_resp,Response for trial 12,Penn Word Memory Test
+CPW_q12_ttr,CPW_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test
+CPW_q12_corr,CPW_q12_corr,Response correct for trial 12,Penn Word Memory Test
+CPW_q13_resp,CPW_q13_resp,Response for trial 13,Penn Word Memory Test
+CPW_q13_ttr,CPW_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test
+CPW_q13_corr,CPW_q13_corr,Response correct for trial 13,Penn Word Memory Test
+CPW_q14_resp,CPW_q14_resp,Response for trial 14,Penn Word Memory Test
+CPW_q14_ttr,CPW_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test
+CPW_q14_corr,CPW_q14_corr,Response correct for trial 14,Penn Word Memory Test
+CPW_q15_resp,CPW_q15_resp,Response for trial 15,Penn Word Memory Test
+CPW_q15_ttr,CPW_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test
+CPW_q15_corr,CPW_q15_corr,Response correct for trial 15,Penn Word Memory Test
+CPW_q16_resp,CPW_q16_resp,Response for trial 16,Penn Word Memory Test
+CPW_q16_ttr,CPW_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test
+CPW_q16_corr,CPW_q16_corr,Response correct for trial 16,Penn Word Memory Test
+CPW_q17_resp,CPW_q17_resp,Response for trial 17,Penn Word Memory Test
+CPW_q17_ttr,CPW_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test
+CPW_q17_corr,CPW_q17_corr,Response correct for trial 17,Penn Word Memory Test
+CPW_q18_resp,CPW_q18_resp,Response for trial 18,Penn Word Memory Test
+CPW_q18_ttr,CPW_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test
+CPW_q18_corr,CPW_q18_corr,Response correct for trial 18,Penn Word Memory Test
+CPW_q19_resp,CPW_q19_resp,Response for trial 19,Penn Word Memory Test
+CPW_q19_ttr,CPW_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test
+CPW_q19_corr,CPW_q19_corr,Response correct for trial 19,Penn Word Memory Test
+CPW_q20_resp,CPW_q20_resp,Response for trial 20,Penn Word Memory Test
+CPW_q20_ttr,CPW_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test
+CPW_q20_corr,CPW_q20_corr,Response correct for trial 20,Penn Word Memory Test
+CPW_q21_resp,CPW_q21_resp,Response for trial 21,Penn Word Memory Test
+CPW_q21_ttr,CPW_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test
+CPW_q21_corr,CPW_q21_corr,Response correct for trial 21,Penn Word Memory Test
+CPW_q22_resp,CPW_q22_resp,Response for trial 22,Penn Word Memory Test
+CPW_q22_ttr,CPW_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test
+CPW_q22_corr,CPW_q22_corr,Response correct for trial 22,Penn Word Memory Test
+CPW_q23_resp,CPW_q23_resp,Response for trial 23,Penn Word Memory Test
+CPW_q23_ttr,CPW_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test
+CPW_q23_corr,CPW_q23_corr,Response correct for trial 23,Penn Word Memory Test
+CPW_q24_resp,CPW_q24_resp,Response for trial 24,Penn Word Memory Test
+CPW_q24_ttr,CPW_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test
+CPW_q24_corr,CPW_q24_corr,Response correct for trial 24,Penn Word Memory Test
+CPW_q25_resp,CPW_q25_resp,Response for trial 25,Penn Word Memory Test
+CPW_q25_ttr,CPW_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test
+CPW_q25_corr,CPW_q25_corr,Response correct for trial 25,Penn Word Memory Test
+CPW_q26_resp,CPW_q26_resp,Response for trial 26,Penn Word Memory Test
+CPW_q26_ttr,CPW_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test
+CPW_q26_corr,CPW_q26_corr,Response correct for trial 26,Penn Word Memory Test
+CPW_q27_resp,CPW_q27_resp,Response for trial 27,Penn Word Memory Test
+CPW_q27_ttr,CPW_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test
+CPW_q27_corr,CPW_q27_corr,Response correct for trial 27,Penn Word Memory Test
+CPW_q28_resp,CPW_q28_resp,Response for trial 28,Penn Word Memory Test
+CPW_q28_ttr,CPW_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test
+CPW_q28_corr,CPW_q28_corr,Response correct for trial 28,Penn Word Memory Test
+CPW_q29_resp,CPW_q29_resp,Response for trial 29,Penn Word Memory Test
+CPW_q29_ttr,CPW_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test
+CPW_q29_corr,CPW_q29_corr,Response correct for trial 29,Penn Word Memory Test
+CPW_q30_resp,CPW_q30_resp,Response for trial 30,Penn Word Memory Test
+CPW_q30_ttr,CPW_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test
+CPW_q30_corr,CPW_q30_corr,Response correct for trial 30,Penn Word Memory Test
+CPW_q31_resp,CPW_q31_resp,Response for trial 31,Penn Word Memory Test
+CPW_q31_ttr,CPW_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test
+CPW_q31_corr,CPW_q31_corr,Response correct for trial 31,Penn Word Memory Test
+CPW_q32_resp,CPW_q32_resp,Response for trial 32,Penn Word Memory Test
+CPW_q32_ttr,CPW_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test
+CPW_q32_corr,CPW_q32_corr,Response correct for trial 32,Penn Word Memory Test
+CPW_q33_resp,CPW_q33_resp,Response for trial 33,Penn Word Memory Test
+CPW_q33_ttr,CPW_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test
+CPW_q33_corr,CPW_q33_corr,Response correct for trial 33,Penn Word Memory Test
+CPW_q34_resp,CPW_q34_resp,Response for trial 34,Penn Word Memory Test
+CPW_q34_ttr,CPW_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test
+CPW_q34_corr,CPW_q34_corr,Response correct for trial 34,Penn Word Memory Test
+CPW_q35_resp,CPW_q35_resp,Response for trial 35,Penn Word Memory Test
+CPW_q35_ttr,CPW_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test
+CPW_q35_corr,CPW_q35_corr,Response correct for trial 35,Penn Word Memory Test
+CPW_q36_resp,CPW_q36_resp,Response for trial 36,Penn Word Memory Test
+CPW_q36_ttr,CPW_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test
+CPW_q36_corr,CPW_q36_corr,Response correct for trial 36,Penn Word Memory Test
+CPW_q37_resp,CPW_q37_resp,Response for trial 37,Penn Word Memory Test
+CPW_q37_ttr,CPW_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test
+CPW_q37_corr,CPW_q37_corr,Response correct for trial 37,Penn Word Memory Test
+CPW_q38_resp,CPW_q38_resp,Response for trial 38,Penn Word Memory Test
+CPW_q38_ttr,CPW_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test
+CPW_q38_corr,CPW_q38_corr,Response correct for trial 38,Penn Word Memory Test
+CPW_q39_resp,CPW_q39_resp,Response for trial 39,Penn Word Memory Test
+CPW_q39_ttr,CPW_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test
+CPW_q39_corr,CPW_q39_corr,Response correct for trial 39,Penn Word Memory Test
+CPW_q40_resp,CPW_q40_resp,Response for trial 40,Penn Word Memory Test
+CPW_q40_ttr,CPW_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test
+CPW_q40_corr,CPW_q40_corr,Response correct for trial 40,Penn Word Memory Test
+CPWD_A_ScorVers,CPWD_Scorvers,Current Programming Version of the Scoring Code,Penn Word Memory Test - Delayed Version
+CPWD_A_status,CPWD_status,Status Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
+CPWD_A_valid_code,CPWD_valid_code,Valid Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TP,CPWD_CPWDTP,CPWD True Positive Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TN,CPWD_CPWDTN,CPWD True Negative Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FP,CPWD_CPWDFP,CPWD False Positive Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FN,CPWD_CPWDFN,CPWD False Negative Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TPRT,CPWD_CPWDTPRT,Median Response Time for CPWD True Positive Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TNRT,CPWD_CPWDTNRT,Median Response Time for CPWD True Negative Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FPRT,CPWD_CPWDFPRT,Median Response Time for CPWD False Positive Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_FNRT,CPWD_CPWDFNRT,Median Response Time for CPWD False Negative Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_CR,CPWD_DWRD_TOT,CPWD Total Correct Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RTCR,CPWD_DWRD_RTC,Median Response Time for CPWD Total Correct Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_W_RTCR,,Weighted Median Response Time for Correct Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_ER,,Total Incorrect Responses,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RTER,,Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_W_RTER,,Weighted Median Response Time for Incorrect Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_RT,,Median Response Time for All Responses (ms),Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_RESP,CPWD_q1_resp,Response for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_TTR,CPWD_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000001_CORR,CPWD_q1_corr,Response correct for trial 1,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_RESP,CPWD_q2_resp,Response for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_TTR,CPWD_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000002_CORR,CPWD_q2_corr,Response correct for trial 2,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_RESP,CPWD_q3_resp,Response for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_TTR,CPWD_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000003_CORR,CPWD_q3_corr,Response correct for trial 3,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_RESP,CPWD_q4_resp,Response for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_TTR,CPWD_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000004_CORR,CPWD_q4_corr,Response correct for trial 4,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_RESP,CPWD_q5_resp,Response for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_TTR,CPWD_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000005_CORR,CPWD_q5_corr,Response correct for trial 5,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_RESP,CPWD_q6_resp,Response for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_TTR,CPWD_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000006_CORR,CPWD_q6_corr,Response correct for trial 6,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_RESP,CPWD_q7_resp,Response for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_TTR,CPWD_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000007_CORR,CPWD_q7_corr,Response correct for trial 7,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_RESP,CPWD_q8_resp,Response for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_TTR,CPWD_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000008_CORR,CPWD_q8_corr,Response correct for trial 8,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_RESP,CPWD_q9_resp,Response for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_TTR,CPWD_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000009_CORR,CPWD_q9_corr,Response correct for trial 9,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_RESP,CPWD_q10_resp,Response for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_TTR,CPWD_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000010_CORR,CPWD_q10_corr,Response correct for trial 10,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_RESP,CPWD_q11_resp,Response for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_TTR,CPWD_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000011_CORR,CPWD_q11_corr,Response correct for trial 11,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_RESP,CPWD_q12_resp,Response for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_TTR,CPWD_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000012_CORR,CPWD_q12_corr,Response correct for trial 12,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_RESP,CPWD_q13_resp,Response for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_TTR,CPWD_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000013_CORR,CPWD_q13_corr,Response correct for trial 13,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_RESP,CPWD_q14_resp,Response for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_TTR,CPWD_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000014_CORR,CPWD_q14_corr,Response correct for trial 14,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_RESP,CPWD_q15_resp,Response for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_TTR,CPWD_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000015_CORR,CPWD_q15_corr,Response correct for trial 15,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_RESP,CPWD_q16_resp,Response for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_TTR,CPWD_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000016_CORR,CPWD_q16_corr,Response correct for trial 16,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_RESP,CPWD_q17_resp,Response for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_TTR,CPWD_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000017_CORR,CPWD_q17_corr,Response correct for trial 17,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_RESP,CPWD_q18_resp,Response for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_TTR,CPWD_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000018_CORR,CPWD_q18_corr,Response correct for trial 18,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_RESP,CPWD_q19_resp,Response for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_TTR,CPWD_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000019_CORR,CPWD_q19_corr,Response correct for trial 19,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_RESP,CPWD_q20_resp,Response for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_TTR,CPWD_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000020_CORR,CPWD_q20_corr,Response correct for trial 20,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_RESP,CPWD_q21_resp,Response for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_TTR,CPWD_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000021_CORR,CPWD_q21_corr,Response correct for trial 21,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_RESP,CPWD_q22_resp,Response for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_TTR,CPWD_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000022_CORR,CPWD_q22_corr,Response correct for trial 22,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_RESP,CPWD_q23_resp,Response for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_TTR,CPWD_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000023_CORR,CPWD_q23_corr,Response correct for trial 23,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_RESP,CPWD_q24_resp,Response for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_TTR,CPWD_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000024_CORR,CPWD_q24_corr,Response correct for trial 24,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_RESP,CPWD_q25_resp,Response for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_TTR,CPWD_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000025_CORR,CPWD_q25_corr,Response correct for trial 25,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_RESP,CPWD_q26_resp,Response for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_TTR,CPWD_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000026_CORR,CPWD_q26_corr,Response correct for trial 26,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_RESP,CPWD_q27_resp,Response for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_TTR,CPWD_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000027_CORR,CPWD_q27_corr,Response correct for trial 27,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_RESP,CPWD_q28_resp,Response for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_TTR,CPWD_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000028_CORR,CPWD_q28_corr,Response correct for trial 28,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_RESP,CPWD_q29_resp,Response for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_TTR,CPWD_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000029_CORR,CPWD_q29_corr,Response correct for trial 29,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_RESP,CPWD_q30_resp,Response for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_TTR,CPWD_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000030_CORR,CPWD_q30_corr,Response correct for trial 30,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_RESP,CPWD_q31_resp,Response for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_TTR,CPWD_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000031_CORR,CPWD_q31_corr,Response correct for trial 31,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_RESP,CPWD_q32_resp,Response for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_TTR,CPWD_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000032_CORR,CPWD_q32_corr,Response correct for trial 32,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_RESP,CPWD_q33_resp,Response for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_TTR,CPWD_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000033_CORR,CPWD_q33_corr,Response correct for trial 33,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_RESP,CPWD_q34_resp,Response for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_TTR,CPWD_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000034_CORR,CPWD_q34_corr,Response correct for trial 34,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_RESP,CPWD_q35_resp,Response for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_TTR,CPWD_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000035_CORR,CPWD_q35_corr,Response correct for trial 35,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_RESP,CPWD_q36_resp,Response for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_TTR,CPWD_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000036_CORR,CPWD_q36_corr,Response correct for trial 36,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_RESP,CPWD_q37_resp,Response for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_TTR,CPWD_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000037_CORR,CPWD_q37_corr,Response correct for trial 37,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_RESP,CPWD_q38_resp,Response for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_TTR,CPWD_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000038_CORR,CPWD_q38_corr,Response correct for trial 38,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_RESP,CPWD_q39_resp,Response for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_TTR,CPWD_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000039_CORR,CPWD_q39_corr,Response correct for trial 39,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_RESP,CPWD_q40_resp,Response for trial 40,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_TTR,CPWD_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
+CPWD_A_CPWD_TRIAL000040_CORR,CPWD_q40_corr,Response correct for trial 40,Penn Word Memory Test - Delayed Version
+MPRACT_ScorVers,MPRACT_Scorvers,Current Programming Version of the Scoring Code,Motor Praxis Test
+MPRACT_status,MPRACT_status,Status Code Assigned to Mouse Praxis ,Motor Praxis Test
+MPRACT_valid_code,MPRACT_valid_code,Valid Code Assigned to Mouse Praxis,Motor Praxis Test
+MPRACT_MP1RT,MPRACT_MP1RT,Median Response Time for Mouse Praxis Trial 1 (ms),Motor Praxis Test
+MPRACT_MP2,MPRACT_MP2,Mouse Praxis Correct Responses Trial 2,Motor Praxis Test
+MPRACT_MP2RTCR,MPRACT_MP2RTCR,Median Response Time for Mouse Praxis Trial 2 Correct Responses (ms),Motor Praxis Test
+PCET_A_ScorVers,PCET_Scorvers,Current Programming Version of the Scoring Code,Penn Conditional Exclusion Test - Form A
+PCET_A_status,PCET_status,Status Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
+PCET_A_valid_code,PCET_valid_code,Valid Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CR,PCET_PCETCR,PCET Number Correct Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RTCR,PCET_PCETRTCR,Median Response Time for PCET Correct Responses (ms),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ER,PCET_PCETER,PCET Number Incorrect Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RTER,PCET_PCETRTER,Median Response Time for PCET Incorrect Responses (ms),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_WIS_PER_ER,PCET_PER_ER,PCET Number of Perseverative Errors,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_WIS_PER_RES,PCET_PER_RES,PCET Perseverative Errors Plus Correct Perseverative Responses,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_EFF,PCET_PCET_EFF,PCET Efficiency = PCET_ACC/log(PCETRTCR),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_NUM,PCET_PCET_NUM,Total Number of Trials,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT,PCET_PCET_CAT,Number of PCET Categories Achieved,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT1_TR,PCET_PCET_CAT1_tr,Number of Trials Required to Achieve Category 1,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT2_TR,PCET_PCET_CAT2_tr,Number of Trials Required to Achieve Category 2,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT3_TR,PCET_PCET_CAT3_tr,Number of Trials Required to Achieve Category 3,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ACC,PCET_PCET_ACC,PCET Accuracy = PCET_CAT * PCETCR/(PCETCR +PCETER),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_ACC2,PCET_PCET_ACC2,PECT Accuracy2 = (PCET_CAT+1)*PCETCR/(PCETCR+PCETER),Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_RT,,Median Response Time for All Responses (ms),Penn Conditional Exclusion Test - Form A
+PMAT24_A_ScorVers,PMAT24A_Scorvers,Current Programming Version of the Scoring Code,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_FORM,PMAT24A_PMAT24_FORM,Form of this administration,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_valid_code,PMAT24A_status,Status Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_CR,PMAT24A_valid_code,Valid Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_PC,PMAT24A_PMAT24_A_CR,PMAT24 Correct Responses for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_SI,PMAT24A_PMAT24_A_SI,PMAT24 Total Skipped Items (items not presented because maximum errors allowed reached) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTCR,PMAT24A_PMAT24_A_RTCR,Median Response Time for Correct PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTER,PMAT24A_PMAT24_A_RTER,Median Response Time for Incorrect PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_RTTO,PMAT24A_PMAT24_A_RTTO,Median Resposne Time for All PMAT24 Responses (ms) for Form A,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_RESP,PMAT24A_q01_resp,Response for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_TTR,PMAT24A_q01_ttr,Time to respond (ms) for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000001_CORR,PMAT24A_q01_corr,Response correct for trial 1,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_RESP,PMAT24A_q02_resp,Response for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_TTR,PMAT24A_q02_ttr,Time to respond (ms) for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000002_CORR,PMAT24A_q02_corr,Response correct for trial 2,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_RESP,PMAT24A_q03_resp,Response for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_TTR,PMAT24A_q03_ttr,Time to respond (ms) for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000003_CORR,PMAT24A_q03_corr,Response correct for trial 3,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_RESP,PMAT24A_q04_resp,Response for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_TTR,PMAT24A_q04_ttr,Time to respond (ms) for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000004_CORR,PMAT24A_q04_corr,Response correct for trial 4,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_RESP,PMAT24A_q05_resp,Response for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_TTR,PMAT24A_q05_ttr,Time to respond (ms) for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000005_CORR,PMAT24A_q05_corr,Response correct for trial 5,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_RESP,PMAT24A_q06_resp,Response for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_TTR,PMAT24A_q06_ttr,Time to respond (ms) for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000006_CORR,PMAT24A_q06_corr,Response correct for trial 6,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_RESP,PMAT24A_q07_resp,Response for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_TTR,PMAT24A_q07_ttr,Time to respond (ms) for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000007_CORR,PMAT24A_q07_corr,Response correct for trial 7,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_RESP,PMAT24A_q08_resp,Response for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_TTR,PMAT24A_q08_ttr,Time to respond (ms) for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000008_CORR,PMAT24A_q08_corr,Response correct for trial 8,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_RESP,PMAT24A_q09_resp,Response for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_TTR,PMAT24A_q09_ttr,Time to respond (ms) for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000009_CORR,PMAT24A_q09_corr,Response correct for trial 9,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_RESP,PMAT24A_q10_resp,Response for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_TTR,PMAT24A_q10_ttr,Time to respond (ms) for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000010_CORR,PMAT24A_q10_corr,Response correct for trial 10,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_RESP,PMAT24A_q11_resp,Response for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_TTR,PMAT24A_q11_ttr,Time to respond (ms) for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000011_CORR,PMAT24A_q11_corr,Response correct for trial 11,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_RESP,PMAT24A_q12_resp,Response for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_TTR,PMAT24A_q12_ttr,Time to respond (ms) for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000012_CORR,PMAT24A_q12_corr,Response correct for trial 12,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_RESP,PMAT24A_q13_resp,Response for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_TTR,PMAT24A_q13_ttr,Time to respond (ms) for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000013_CORR,PMAT24A_q13_corr,Response correct for trial 13,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_RESP,PMAT24A_q14_resp,Response for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_TTR,PMAT24A_q14_ttr,Time to respond (ms) for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000014_CORR,PMAT24A_q14_corr,Response correct for trial 14,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_RESP,PMAT24A_q15_resp,Response for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_TTR,PMAT24A_q15_ttr,Time to respond (ms) for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000015_CORR,PMAT24A_q15_corr,Response correct for trial 15,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_RESP,PMAT24A_q16_resp,Response for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_TTR,PMAT24A_q16_ttr,Time to respond (ms) for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000016_CORR,PMAT24A_q16_corr,Response correct for trial 16,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_RESP,PMAT24A_q17_resp,Response for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_TTR,PMAT24A_q17_ttr,Time to respond (ms) for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000017_CORR,PMAT24A_q17_corr,Response correct for trial 17,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_RESP,PMAT24A_q18_resp,Response for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_TTR,PMAT24A_q18_ttr,Time to respond (ms) for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000018_CORR,PMAT24A_q18_corr,Response correct for trial 18,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_RESP,PMAT24A_q19_resp,Response for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_TTR,PMAT24A_q19_ttr,Time to respond (ms) for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000019_CORR,PMAT24A_q19_corr,Response correct for trial 19,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_RESP,PMAT24A_q20_resp,Response for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_TTR,PMAT24A_q20_ttr,Time to respond (ms) for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000020_CORR,PMAT24A_q20_corr,Response correct for trial 20,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_RESP,PMAT24A_q21_resp,Response for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_TTR,PMAT24A_q21_ttr,Time to respond (ms) for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000021_CORR,PMAT24A_q21_corr,Response correct for trial 21,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_RESP,PMAT24A_q22_resp,Response for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_TTR,PMAT24A_q22_ttr,Time to respond (ms) for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000022_CORR,PMAT24A_q22_corr,Response correct for trial 22,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_RESP,PMAT24A_q23_resp,Response for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_TTR,PMAT24A_q23_ttr,Time to respond (ms) for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_TRIAL,,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000023_CORR,,Response correct for trial 23,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_RESP,PMAT24A_q23_corr,Response for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_TTR,PMAT24A_q24_resp,Time to respond (ms) for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_TRIAL,PMAT24A_q24_ttr,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_PMAT24_A_QID000024_CORR,PMAT24A_q24_corr,Response correct for trial 24,Penn Matrix Analysis Test - Form A - 24 items
+PVOC_ScorVers,PVOC_Scorvers,Current Programming Version of the Scoring Code,Penn Vocabulary Test
+PVOC_status,PVOC_status,Status Code Assigned to PVOC,Penn Vocabulary Test
+PVOC_valid_code,PVOC_valid_code,Valid Code Assigned to PVOC,Penn Vocabulary Test
+PVOC_PVOC1,PVOC_PVOC1,PVOC Correct Responses for Items 1-10,Penn Vocabulary Test
+PVOC_PVOC2,PVOC_PVOC2,PVOC Correct Responses for Items 11-20,Penn Vocabulary Test
+PVOC_PVOC3,PVOC_PVOC3,PVOC Correct Responses for Items 21-30,Penn Vocabulary Test
+PVOC_PVOC4,PVOC_PVOC4,PVOC Correct Responses for Items 31-40,Penn Vocabulary Test
+PVOC_PVOC5,PVOC_PVOC5,PVOC Correct Responses for Items 41-50,Penn Vocabulary Test
+PVOC_PVOCCR,PVOC_PVOCCR,PVOC Total Correct Responses,Penn Vocabulary Test
+PVOC_PVOCNR,PVOC_PVOCNR,PVOC Total Non-Responses,Penn Vocabulary Test
+PVOC_PVOC1RTCR,PVOC_PVOC1RTCR,Median Response Time for correct PVOC1 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC2RTCR,PVOC_PVOC2RTCR,Median Response Time for correct PVOC2 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC3RTCR,PVOC_PVOC3RTCR,Median Response Time for correct PVOC3 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC4RTCR,PVOC_PVOC4RTCR,Median Response Time for correct PVOC4 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC5RTCR,PVOC_PVOC5RTCR,Median Response Time for correct PVOC5 Trials (ms),Penn Vocabulary Test
+PVOC_PVOCRTCR,PVOC_PVOCRTCR,Median Response Time for correct PVOC (All Trials) (ms),Penn Vocabulary Test
+PVOC_PVOC1RTER,PVOC_PVOC1RTER,Median Response Time for incorrect PVOC1 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC2RTER,PVOC_PVOC2RTER,Median Response Time for incorrect PVOC2 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC3RTER,PVOC_PVOC3RTER,Median Response Time for incorrect PVOC3 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC4RTER,PVOC_PVOC4RTER,Median Response Time for incorrect PVOC4 Trials (ms),Penn Vocabulary Test
+PVOC_PVOC5RTER,PVOC_PVOC5RTER,Median Response Time for incorrect PVOC5 Trials (ms),Penn Vocabulary Test
+PVOC_PVOCRTER,PVOC_PVOCRTER,Median Response Time for incorrect PVOC (All Trials) (ms),Penn Vocabulary Test
+PVOC_PVOC_Q1,PVOC_PVOC_Q1,PVOC Q1: Were all of the instructions clear?,Penn Vocabulary Test
+PVOC_PVOC_Q2,PVOC_PVOC_Q2,PVOC Q2: Did you have enough time to complete each item?,Penn Vocabulary Test
+PVOC_PVOC_Q3,PVOC_PVOC_Q3,PVOC Q3: Are you a native speaker of English?,Penn Vocabulary Test
+PVOC_PVOC_Q4,PVOC_PVOC_Q4,"PVOC Q4: If no, at what age did you learn English?",Penn Vocabulary Test
+PVOC_PVOC_Q5,PVOC_PVOC_Q5,PVOC Q5: Most recent Verbal SAT score,Penn Vocabulary Test
+PVOC_PVOC_Q6,PVOC_PVOC_Q6,PVOC Q6: Most recent Math SAT score,Penn Vocabulary Test
+PVOC_PVOC_Q7,PVOC_PVOC_Q7,PVOC Q7: SAT Year Taken,Penn Vocabulary Test
+PVOC_RES_1,PVOC_RES_1,Response for Item 1,Penn Vocabulary Test
+PVOC_RES_2,PVOC_RES_2,Response for Item 2,Penn Vocabulary Test
+PVOC_RES_3,PVOC_RES_3,Response for Item 3,Penn Vocabulary Test
+PVOC_RES_4,PVOC_RES_4,Response for Item 4,Penn Vocabulary Test
+PVOC_RES_5,PVOC_RES_5,Response for Item 5,Penn Vocabulary Test
+PVOC_RES_6,PVOC_RES_6,Response for Item 6,Penn Vocabulary Test
+PVOC_RES_7,PVOC_RES_7,Response for Item 7,Penn Vocabulary Test
+PVOC_RES_8,PVOC_RES_8,Response for Item 8,Penn Vocabulary Test
+PVOC_RES_9,PVOC_RES_9,Response for Item 9,Penn Vocabulary Test
+PVOC_RES_10,PVOC_RES_10,Response for Item 10,Penn Vocabulary Test
+PVOC_RES_11,PVOC_RES_11,Response for Item 11,Penn Vocabulary Test
+PVOC_RES_12,PVOC_RES_12,Response for Item 12,Penn Vocabulary Test
+PVOC_RES_13,PVOC_RES_13,Response for Item 13,Penn Vocabulary Test
+PVOC_RES_14,PVOC_RES_14,Response for Item 14,Penn Vocabulary Test
+PVOC_RES_15,PVOC_RES_15,Response for Item 15,Penn Vocabulary Test
+PVOC_RES_16,PVOC_RES_16,Response for Item 16,Penn Vocabulary Test
+PVOC_RES_17,PVOC_RES_17,Response for Item 17,Penn Vocabulary Test
+PVOC_RES_18,PVOC_RES_18,Response for Item 18,Penn Vocabulary Test
+PVOC_RES_19,PVOC_RES_19,Response for Item 19,Penn Vocabulary Test
+PVOC_RES_20,PVOC_RES_20,Response for Item 20,Penn Vocabulary Test
+PVOC_RES_21,PVOC_RES_21,Response for Item 21,Penn Vocabulary Test
+PVOC_RES_22,PVOC_RES_22,Response for Item 22,Penn Vocabulary Test
+PVOC_RES_23,PVOC_RES_23,Response for Item 23,Penn Vocabulary Test
+PVOC_RES_24,PVOC_RES_24,Response for Item 24,Penn Vocabulary Test
+PVOC_RES_25,PVOC_RES_25,Response for Item 25,Penn Vocabulary Test
+PVOC_RES_26,PVOC_RES_26,Response for Item 26,Penn Vocabulary Test
+PVOC_RES_27,PVOC_RES_27,Response for Item 27,Penn Vocabulary Test
+PVOC_RES_28,PVOC_RES_28,Response for Item 28,Penn Vocabulary Test
+PVOC_RES_29,PVOC_RES_29,Response for Item 29,Penn Vocabulary Test
+PVOC_RES_30,PVOC_RES_30,Response for Item 30,Penn Vocabulary Test
+PVOC_RES_31,PVOC_RES_31,Response for Item 31,Penn Vocabulary Test
+PVOC_RES_32,PVOC_RES_32,Response for Item 32,Penn Vocabulary Test
+PVOC_RES_33,PVOC_RES_33,Response for Item 33,Penn Vocabulary Test
+PVOC_RES_34,PVOC_RES_34,Response for Item 34,Penn Vocabulary Test
+PVOC_RES_35,PVOC_RES_35,Response for Item 35,Penn Vocabulary Test
+PVOC_RES_36,PVOC_RES_36,Response for Item 36,Penn Vocabulary Test
+PVOC_RES_37,PVOC_RES_37,Response for Item 37,Penn Vocabulary Test
+PVOC_RES_38,PVOC_RES_38,Response for Item 38,Penn Vocabulary Test
+PVOC_RES_39,PVOC_RES_39,Response for Item 39,Penn Vocabulary Test
+PVOC_RES_40,PVOC_RES_40,Response for Item 40,Penn Vocabulary Test
+PVOC_RES_41,PVOC_RES_41,Response for Item 41,Penn Vocabulary Test
+PVOC_RES_42,PVOC_RES_42,Response for Item 42,Penn Vocabulary Test
+PVOC_RES_43,PVOC_RES_43,Response for Item 43,Penn Vocabulary Test
+PVOC_RES_44,PVOC_RES_44,Response for Item 44,Penn Vocabulary Test
+PVOC_RES_45,PVOC_RES_45,Response for Item 45,Penn Vocabulary Test
+PVOC_RES_46,PVOC_RES_46,Response for Item 46,Penn Vocabulary Test
+PVOC_RES_47,PVOC_RES_47,Response for Item 47,Penn Vocabulary Test
+PVOC_RES_48,PVOC_RES_48,Response for Item 48,Penn Vocabulary Test
+PVOC_RES_49,PVOC_RES_49,Response for Item 49,Penn Vocabulary Test
+PVOC_RES_50,PVOC_RES_50,Response for Item 50,Penn Vocabulary Test
+PVRT_ScorVers,SPVRT_Scorvers,Current Programming Version of the Scoring Code,Penn Logical Reasoning Test - Short Version
+PVRT_status,PVRT_form,Form of the PVRT,Penn Logical Reasoning Test - Short Version
+PVRT_valid_code,PVRT_status,Status Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_FORM,PVRT_valid_code,Valid Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTCR,PVRT_PVRTCR,Correct Responses for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_PC,PVRT_PVRT_PC,Percent Correct for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTTO,PVRT_PVRTRTTO,All Responses Median Response Time (ms) for SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTCR,PVRT_PVRTRTCR,SPVRT Median Response Time for Correct Responses (ms),Penn Logical Reasoning Test - Short Version
+PVRT_PVRTRTER,PVRT_PVRTRTER,SPVRT Median Response Time for Incorrect Responses (ms),Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_EFF,PVRT_PVRT_EFF,PVRT Efficiency = PVRT_PC/log(PVRTRTCR),Penn Logical Reasoning Test - Short Version
+SHORTVOLT_ScorVers,SVOLT_Scorvers,Current Programming Version of the Scoring Code,Visual Object Learning Test - Short Version
+SHORTVOLT_status,SHORTVOLT_status,Status Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SHORTVOLT_valid_code,SHORTVOLT_valid_code,Valid Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SHORTVOLT_SVT,SHORTVOLT_SVT,SVOLT Total Correct,Visual Object Learning Test - Short Version
+SHORTVOLT_SVTRT,SHORTVOLT_SVTRT,Median Response Time for Short VOLT All Responses (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTCRT,SHORTVOLT_SVTCRT,Median Response Time for SVOLT Correct Responses (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTIRT,SHORTVOLT_SVTIRT,Median Response Time for SVOLT Incorrect Responses (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTTP,SHORTVOLT_SVTTP,SVOLT True Positive Responses,Visual Object Learning Test - Short Version
+SHORTVOLT_SVTTN,SHORTVOLT_SVTTN,SVOLT True Negative Responses,Visual Object Learning Test - Short Version
+SHORTVOLT_SVTFP,SHORTVOLT_SVTFP,SVOLT False Positive Responses,Visual Object Learning Test - Short Version
+SHORTVOLT_SVTFN,SHORTVOLT_SVTFN,SVOLT False Negative Responses,Visual Object Learning Test - Short Version
+SHORTVOLT_SVTTPRT,SHORTVOLT_SVTTPRT,SVOLT True Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTTNRT,SHORTVOLT_SVTTNRT,SVOLT True Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTFPRT,SHORTVOLT_SVTFPRT,SVOLT False Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVTFNRT,SHORTVOLT_SVTFNRT,SVOLT False Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SHORTVOLT_SVT_EFF,SHORTVOLT_SVT_EFF,Short VOLT Efficiency ,Visual Object Learning Test - Short Version
+SPCPTNL_ScorVers,SPCPTNL_test,Current Programming Version of the Scoring Code,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_status,SPCPTNL_status,Status Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_valid_code,SPCPTNL_valid_code,Valid Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TP,SPCPTNL_SCPN_TP,NumLet True Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FP,SPCPTNL_SCPN_FP,NumLet False Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TN,SPCPTNL_SCPN_TN,NumLet True Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FN,SPCPTNL_SCPN_FN,NumLet False Negative Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_TPRT,SPCPTNL_SCPN_TPRT,Median Response Time for NumLet True Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_FPRT,SPCPTNL_SCPN_FPRT,Median Response Time for NumLet False Positive Responses for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TP,SPCPTNL_SCPL_TP,NumLet True Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FP,SPCPTNL_SCPL_FP,NumLet False Positive Responses for Letter Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TN,SPCPTNL_SCPL_TN,NumLet True Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FN,SPCPTNL_SCPL_FN,NumLet False Negative Responses for Letters Trials,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_TPRT,SPCPTNL_SCPL_TPRT,Median Response Time for NumLet True Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_FPRT,SPCPTNL_SCPL_FPRT,Median Response Time for NumLet False Positive Responses for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FN,SPCPTNL_SCPT_FN,NumLet CPT False Negatives - Sum of SCPN_FN and SCPL_FN,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FP,SPCPTNL_SCPT_FP,NumLet CPT False Positives - Sum of SCPN_FP and SCPL_FP,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TP,SPCPTNL_SCPT_TP,NumLet CPT True Positives - Sum of SCPN_TP and SCPL_TP,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TN,SPCPTNL_SCPT_TN,NumLet CPT True Negatives - Sum of SCPN_TN and SCPL_TN,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_TPRT,SPCPTNL_SCPT_TPRT,Median Response Time for NumLet True Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FPRT,SPCPTNL_SCPT_FPRT,Median Response Time for NumLet False Positive Responses (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPN_RT,,Median Response Time for Number Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPL_RT,,Median Response Time for Letter Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_RT,,Median Response Time for All Trials (ms),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_SEN,,Sensitivity = SCPT_TP/(SCPT_TP + SCPT_FN),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_SPEC,,Specificity = SCPT_TN/(SCPT_TN + SCPT_FP),Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_LRNR,SPCPTNL_SCPT_LRNR,NumLet CPT Longest Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
+SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,NumLet CPT Final Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
+SVOLTD_A_ScorVers,SVOLTD_Scorvers,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_status,SVDELAY_status,Status Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_valid_code,SVDELAY_valid_code,Valid Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVTLDRTC,SVDELAY_SVTLDRTC,Median Response Time for SVOLTD Correct Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVTLDRTER,SVDELAY_SVTLDRTER,Median Response Time for SVOLTD Incorrect Responses (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTP,SVDELAY_SVT_LDTP,SVOLTD True Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTN,SVDELAY_SVT_LDTN,SVOLTD True Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFP,SVDELAY_SVT_LDFP,SVOLTD False Positive Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFN,SVDELAY_SVT_LDFN,SVOLTD False Negative Responses,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTPRT,SVDELAY_SVT_LDTPRT,SVOLTD True Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
+SFNB2_ScorVers,SFNB2_Scorvers,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
+SFNB2_status,SFNB2_status,SFNB2 completion status,Short Fractal-N-Back- 2 Back Version
+SFNB2_valid_code,SFNB2_valid_code,SFNB2 valid code,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP,SFNB2_SFNB_TP,SFNB2 True Positive Responses,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP,SFNB2_SFNB_FP,SFNB2 False Positive Responses,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC,SFNB2_SFNB_RTC,SFNB2 Median Response Time for All Correct Responses (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP0,SFNB2_SFNB_TP0,SFNB2 True Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP0,SFNB2_SFNB_FP0,SFNB2 False Positive Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC0,SFNB2_SFNB_RTC0,SFNB2 Median Response Time for Correct 0-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP1,SFNB2_SFNB_TP1,SFNB2 True Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP1,SFNB2_SFNB_FP1,SFNB2 False Positive Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC1,SFNB2_SFNB_RTC1,SFNB2 Median Response Time for Correct 1-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TP2,SFNB2_SFNB_TP2,SFNB2 True Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FP2,SFNB2_SFNB_FP2,SFNB2 False Positive Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN0,SFNB2_SFNB_TN0,SFNB2 True Negative Responses for 0-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN1,SFNB2_SFNB_TN1,SFNB2 True Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_TN2,SFNB2_SFNB_TN2,SFNB2 True Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FN1,SFNB2_SFNB_FN1,SFNB2 False Negative Responses for 1-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_FN2,SFNB2_SFNB_FN2,SFNB2 False Negative Responses for 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_RTC2,SFNB2_SFNB_RTC2,SFNB2 Median Response Time for Correct 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MCR,SFNB2_SFNB_MCR,SFNB2 True Positive Reponses for 1-Back and 2-Back Trials,Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MRTC,SFNB2_SFNB_MRTC,SFNB2 Mean of Median RT for True Positive Responses for 1-Back and for 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MRT,,SFNB2 Median Response Time for All Responses (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MEFF,,SFNB2 Efficiency = SFNB_MCR/log(SFNB_MRTC),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MSEN,,SFNB2 Sensitivity = (SFNB_TP1 + SFNB_TP2)/(SFNB_TP1 + SFNB_TP2 +SFNB_FN1 + SFNB_FN2),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MSPEC,,SFNB2 Specificity = (SFNB_TN1 + SFNB_TN2)/(SFNB_TN1 + SFNB_TN2 +SFNB_FP1 + SFNB_FP2),Short Fractal-N-Back- 2 Back Version
+ER40_D_ScorVers,ER40D_Scorvers,Current Programming Version of the Scoring Code,Emotion Recognition Task- Form D- 40 items 
+ER40_D_status,ER40D_status,ER40 completion status,Emotion Recognition Task- Form D- 40 items 
+ER40_D_valid_code,ER40D_valid_code,ER40 valid code,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CR,ER40D_ER40_CR,ER40 Correct Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_RTCR,ER40D_ER40_CRT,ER40 Correct Responses Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_RT,,Median Response Time for All Trials (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FC,ER40D_ER40_FC,ER40 Correct Female Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MC,ER40D_ER40_MC,ER40 Correct Male Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FCRT,ER40D_ER40FCRT,ER40 Correct Female Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MCRT,ER40D_ER40MCRT,ER40 Correct Male Identifications Median Response Time (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_ANG,ER40D_ER40ANG,ER40 Correct Anger Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FEAR,ER40D_ER40FEAR,ER40 Correct Fear Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_HAP,ER40D_ER40HAP,ER40 Correct Happy Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_NOE,ER40D_ER40NOE,ER40 Correct No Emotion Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_SAD,ER40D_ER40SAD,ER40 Correct Sad Identifications,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FACR,ER40D_ER40FACR,ER40 Correct Anger Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFCR,ER40D_ER40FFCR,ER40 Correct Fear Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHCR,ER40D_ER40FHCR,ER40 Correct Happy Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNCR,ER40D_ER40FNCR,ER40 Correct No Emotion Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSCR,ER40D_ER40FSCR,ER40 Correct Sad Identifications for Female faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MACR,ER40D_ER40MACR,ER40 Correct Anger Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFCR,ER40D_ER40MFCR,ER40 Correct Fear Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHCR,ER40D_ER40MHCR,ER40 Correct Happy Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNCR,ER40D_ER40MNCR,ER40 Correct No Emotion Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSCR,ER40D_ER40MSCR,ER40 Correct Sad Identifications for Male faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPA,ER40D_ER40_FPA,ER40 False Positive Anger Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPF,ER40D_ER40_FPF,ER40 False Positive Fear Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPH,ER40D_ER40_FPH,ER40 False Positive Happy Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPN,ER40D_ER40_FPN,ER40 False Positive No Emotion Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPS,ER40D_ER40_FPS,ER40 False Positive Sad Responses,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_ANGRT,ER40D_ER40ANGRT,Median Response Time for ER40 Correct Anger Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FEARRT,ER40D_ER40FEARRT,Median Response Time for ER40 Correct Fear Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_HAPRT,ER40D_ER40HAPRT,Median Response Time for ER40 Correct Happy Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_NOERT,ER40D_ER40NOERT,Median Response Time for ER40 Correct No Emotion Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_SADRT,ER40D_ER40SADRT,Median Response Time for ER40 Correct Sad Identifications (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FART,ER40D_ER40FART,Median Response Time for ER40 Correct Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFRT,ER40D_ER40FFRT,Median Response Time for ER40 Correct Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHRT,ER40D_ER40FHRT,Median Response Time for ER40 Correct Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNRT,ER40D_ER40FNRT,Median Response Time for ER40 Correct No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSRT,ER40D_ER40FSRT,Median Response Time for ER40 Correct Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MART,ER40D_ER40MART,Median Response Time for ER40 Correct Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFRT,ER40D_ER40MFRT,Median Response Time for ER40 Correct Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHRT,ER40D_ER40MHRT,Median Response Time for ER40 Correct Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNRT,ER40D_ER40MNRT,Median Response Time for ER40 Correct No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSRT,ER40D_ER40MSRT,Median Response Time for ER40 Correct Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FAERT,ER40D_ER40FAERT,Median Response Time for ER40 Incorrect Anger Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FFERT,ER40D_ER40FFERT,Median Response Time for ER40 Incorrect Fear Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FHERT,ER40D_ER40FHERT,Median Response Time for ER40 Incorrect Happy Identifications for Female faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FNERT,ER40D_ER40FNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FSERT,ER40D_ER40FSERT,Median Response Time for ER40 Incorrect Sad Identifications for Female faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MAERT,ER40D_ER40MAERT,Median Response Time for ER40 Incorrect Anger Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MFERT,ER40D_ER40MFERT,Median Response Time for ER40 Incorrect Fear Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MHERT,ER40D_ER40MHERT,Median Response Time for ER40 Incorrect Happy Identifications for Male faces(ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MNERT,ER40D_ER40MNERT,Median Response Time for ER40 Incorrect No Emotion Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_MSERT,ER40D_ER40MSERT,Median Response Time for ER40 Incorrect Sad Identifications for Male faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPART,ER40D_ER40_FPART,Median Response Time for ER40 False Positive Anger Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPFRT,ER40D_ER40_FPFRT,Median Response Time for ER40 False Positive Fear Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPHRT,ER40D_ER40_FPHRT,Median Response Time for ER40 False Positive Happy Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPNRT,ER40D_ER40_FPNRT,Median Response Time for ER40 False Positive No Emotion Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_FPSRT,ER40D_ER40_FPSRT,Median Response Time for ER40 False Positive Sad Responses (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CACR,ER40D_ER40CACR,ER40 Correct Identifications of Caucasian faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_AACR,ER40D_ER40AACR,ER40 Correct Identifications of African American faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_OTHCR,ER40D_ER40OTHCR,ER40 Correct Identifications of Other Race faces,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_CACRT,ER40D_ER40CACRT,ER40 Median Response Time for Correct Identifications of Caucasian faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_AACRT,ER40D_ER40AACRT,ER40 Median Response Time for Correct Identifications of African American faces (ms),Emotion Recognition Task- Form D- 40 items 
+ER40_D_ER40D_OTHCRT,ER40D_ER40OTHCRT,ER40 Median Response Time for Correct Identifications of Other Race faces (ms),Emotion Recognition Task- Form D- 40 items 
+MEDF36_A_ScorVers,MEDF36_Scorvers,Current Programming Version of the Scoring Code,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_status,MEDF36_status,MEDF36 completion status,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_valid_code,MEDF36_valid_code,MEDF36 valid code,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CR,MEDF36_MEDF36_A,Total Correct Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PC,,Percent Correct Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_RTCR,MEDF36_MEDF36_T,Median Response Time for All Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ER,,Total Incorrect Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_RTER,,Median Response Time for Incorrect Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_CR,MEDF36_MEDF36_ANG_CR,Correct Responses for Measured Emodiff Angry Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_RTCR,MEDF36_MEDF36_ANG_RTCR,Median Response Time for Correct Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_ER,,Total Incorrect Anger Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_ANG_RTER,MEDF36_MEDF36_ANG_RTER,Median Response Time for Incorrect Measured Emodiff Angry Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CA_CR,,Total Correct Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_CA_RTCR,,Median Response Time for Correct Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT10_CR,,Total Correct 10 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT10_RTCR,,Median Response Time for Correct 10 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT20_CR,,Total Correct 20 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT20_RTCR,,Median Response Time for Correct 20 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT30_CR,,Total Correct 30 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT30_RTCR,,Median Response Time for Correct 30 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT40_CR,,Total Correct 40 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT40_RTCR,,Median Response Time for Correct 40 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT50_CR,,Total Correct 50 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT50_RTCR,,Median Response Time for Correct 50 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT60_CR,,Total Correct 60 Percent Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_PCT60_RTCR,,Median Response Time for Correct 60 Percent Difference Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_CR,MEDF36_MEDF36_FEAR_CR,Correct Responses for Measured Emodiff Fear Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_RTCR,MEDF36_MEDF36_FEAR_RTCR,Median Response Time for Correct Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_ER,,Total Incorrect Fear Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEAR_RTER,MEDF36_MEDF36_FEAR_RTER,Median Response Time for Incorrect Measured Emodiff Fear Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEMALE_CR,,Total Correct Female Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_FEMALE_RTCR,,Median Response Time for Correct Female Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_CR,MEDF36_MEDF36_HAP_CR,Correct Responses for Measured Emodiff Happy Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_RTCR,MEDF36_MEDF36_HAP_RTCR,Median Response Time for Correct Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_ER,,Total Incorrect Happy Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_HAP_RTER,MEDF36_MEDF36_HAP_RTER,Median Response Time for Incorrect Measured Emodiff Happy Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_MALE_CR,,Total Correct Male Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_MALE_RTCR,,Median Response Time for Correct Male Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NONCA_CR,,Total Correct Non-Caucasian Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NONCA_RTCR,,Median Response Time for Correct Non-Caucasian Trial Responses (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NS_CR,MEDF36_MEDF36_NS_CR,"Total Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_NS_RTCR,MEDF36_MEDF36_NS_RTCR,"Median Response Time for Correct Emotion Differentiation Test Trials, Excluding Same Trials",Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_CR,MEDF36_MEDF36_SAD_CR,Correct Responses for Measured Emodiff Sad Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_RTCR,MEDF36_MEDF36_SAD_RTCR,Median Response Time for Correct Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_ER,,Total Incorrect Sad Trial Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAD_RTER,MEDF36_MEDF36_SAD_RTER,Median Response Time for Incorrect Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_CR,,Total Incorrect Anger Same (No Difference) Responses,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_CR,Correct Responses for Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_RTCR,Median Response Time for Correct Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items

--- a/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
+++ b/scripts/import/webcnp/NCANDA_Survey_Codebook.csv
@@ -1,9 +1,9 @@
-﻿NCANDA Survey Variable Name,EVIONI2 Variable Name,Variable Description,Test Source
+survey_var,evioni_var,description,test
 test_sessions_datasetid,test_sessions_datasetid,Unique Number for that CNB,Test Sessions
 test_sessions_siteid,test_sessions_siteid,Site ID battery was administered to,Test Sessions
 test_sessions_famid,test_sessions_famid,Family ID battery was administered to,Test Sessions
 test_sessions_subid,test_sessions_subid,Subject ID battery was administered to,Test Sessions
-test_sessions_bblid,test_sessions_bblid,BBLID battery was administered to,Test Sessions
+test_sessions_v_bblid,test_sessions_bblid,BBLID battery was administered to,Test Sessions
 test_sessions_v_battery,test_sessions_battery,Battery Name,Test Sessions
 test_sessions_v_age,test_sessions_age,Age of participant,Test Sessions
 test_sessions_v_gender,test_sessions_gender,Gender of participant,Test Sessions
@@ -15,140 +15,140 @@ test_sessions_v_feducation,test_sessions_feducation,Highest Level of Education o
 test_sessions_v_meducation,test_sessions_meducation,Highest Level of Education of participant's mother,Test Sessions
 test_sessions_v_admin_comments,test_sessions_admin_comments,Administrator Comments,Test Sessions
 test_sessions_v_valid_code,test_sessions_valid_code,Validation Code Assigned,Test Sessions
-CPF_ScorVers,CPF_Scorvers,Current Programming Version of the Scoring Code,Penn Facial Memory Test
-CPF_status,CPF_status,Status Code Assigned to CPF,Penn Facial Memory Test
-CPF_valid_code,CPF_valid_code,Valid Code Assigned to CPF,Penn Facial Memory Test
-CPF_CPFTP,CPF_CPFTP,CPF True Positives,Penn Facial Memory Test
-CPF_CPFTN,CPF_CPFTN,CPF True Negatives,Penn Facial Memory Test
-CPF_CPFFP,CPF_CPFFP,CPF False Positives,Penn Facial Memory Test
-CPF_CPFFN,CPF_CPFFN,CPF False Negatives,Penn Facial Memory Test
-CPF_CPFTPRT,CPF_CPFTPRT,CPF True Positives Median Response Time (ms),Penn Facial Memory Test
-CPF_CPFTNRT,CPF_CPFTNRT,CPF True Negatives Median Response Time (ms),Penn Facial Memory Test
-CPF_CPFFPRT,CPF_CPFFPRT,CPF False Positives Median Response Time (ms),Penn Facial Memory Test
-CPF_CPFFNRT,CPF_CPFFNRT,CPF False Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_ScorVers,CPF,Current Programming Version of the Scoring Code,Penn Facial Memory Test
+CPF_A_status,CPF_status,Status Code Assigned to CPF,Penn Facial Memory Test
+CPF_A_valid_code,CPF_valid_code,Valid Code Assigned to CPF,Penn Facial Memory Test
+CPF_A_CPF_TP,CPF_CPFTP,CPF True Positives,Penn Facial Memory Test
+CPF_A_CPF_TN,CPF_CPFTN,CPF True Negatives,Penn Facial Memory Test
+CPF_A_CPF_FP,CPF_CPFFP,CPF False Positives,Penn Facial Memory Test
+CPF_A_CPF_FN,CPF_CPFFN,CPF False Negatives,Penn Facial Memory Test
+CPF_A_CPF_TPRT,CPF_CPFTPRT,CPF True Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_TNRT,CPF_CPFTNRT,CPF True Negatives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_FPRT,CPF_CPFFPRT,CPF False Positives Median Response Time (ms),Penn Facial Memory Test
+CPF_A_CPF_FNRT,CPF_CPFFNRT,CPF False Negatives Median Response Time (ms),Penn Facial Memory Test
 CPF_IFAC_TOT,CPF_IFAC_TOT,CPF Total Correct Responses,Penn Facial Memory Test
 CPF_IFAC_RTC,CPF_IFAC_RTC,CPF Median Total Correct Response Time (ms),Penn Facial Memory Test
-CPF_q1_resp,CPF_q1_resp,Response for trial 1,Penn Facial Memory Test
-CPF_q1_ttr,CPF_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test
-CPF_q1_corr,CPF_q1_corr,Response correct for trial 1,Penn Facial Memory Test
-CPF_q2_resp,CPF_q2_resp,Response for trial 2,Penn Facial Memory Test
-CPF_q2_ttr,CPF_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test
-CPF_q2_corr,CPF_q2_corr,Response correct for trial 2,Penn Facial Memory Test
-CPF_q3_resp,CPF_q3_resp,Response for trial 3,Penn Facial Memory Test
-CPF_q3_ttr,CPF_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test
-CPF_q3_corr,CPF_q3_corr,Response correct for trial 3,Penn Facial Memory Test
-CPF_q4_resp,CPF_q4_resp,Response for trial 4,Penn Facial Memory Test
-CPF_q4_ttr,CPF_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test
-CPF_q4_corr,CPF_q4_corr,Response correct for trial 4,Penn Facial Memory Test
-CPF_q5_resp,CPF_q5_resp,Response for trial 5,Penn Facial Memory Test
-CPF_q5_ttr,CPF_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test
-CPF_q5_corr,CPF_q5_corr,Response correct for trial 5,Penn Facial Memory Test
-CPF_q6_resp,CPF_q6_resp,Response for trial 6,Penn Facial Memory Test
-CPF_q6_ttr,CPF_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test
-CPF_q6_corr,CPF_q6_corr,Response correct for trial 6,Penn Facial Memory Test
-CPF_q7_resp,CPF_q7_resp,Response for trial 7,Penn Facial Memory Test
-CPF_q7_ttr,CPF_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test
-CPF_q7_corr,CPF_q7_corr,Response correct for trial 7,Penn Facial Memory Test
-CPF_q8_resp,CPF_q8_resp,Response for trial 8,Penn Facial Memory Test
-CPF_q8_ttr,CPF_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test
-CPF_q8_corr,CPF_q8_corr,Response correct for trial 8,Penn Facial Memory Test
-CPF_q9_resp,CPF_q9_resp,Response for trial 9,Penn Facial Memory Test
-CPF_q9_ttr,CPF_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test
-CPF_q9_corr,CPF_q9_corr,Response correct for trial 9,Penn Facial Memory Test
-CPF_q10_resp,CPF_q10_resp,Response for trial 10,Penn Facial Memory Test
-CPF_q10_ttr,CPF_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test
-CPF_q10_corr,CPF_q10_corr,Response correct for trial 10,Penn Facial Memory Test
-CPF_q11_resp,CPF_q11_resp,Response for trial 11,Penn Facial Memory Test
-CPF_q11_ttr,CPF_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test
-CPF_q11_corr,CPF_q11_corr,Response correct for trial 11,Penn Facial Memory Test
-CPF_q12_resp,CPF_q12_resp,Response for trial 12,Penn Facial Memory Test
-CPF_q12_ttr,CPF_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test
-CPF_q12_corr,CPF_q12_corr,Response correct for trial 12,Penn Facial Memory Test
-CPF_q13_resp,CPF_q13_resp,Response for trial 13,Penn Facial Memory Test
-CPF_q13_ttr,CPF_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test
-CPF_q13_corr,CPF_q13_corr,Response correct for trial 13,Penn Facial Memory Test
-CPF_q14_resp,CPF_q14_resp,Response for trial 14,Penn Facial Memory Test
-CPF_q14_ttr,CPF_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test
-CPF_q14_corr,CPF_q14_corr,Response correct for trial 14,Penn Facial Memory Test
-CPF_q15_resp,CPF_q15_resp,Response for trial 15,Penn Facial Memory Test
-CPF_q15_ttr,CPF_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test
-CPF_q15_corr,CPF_q15_corr,Response correct for trial 15,Penn Facial Memory Test
-CPF_q16_resp,CPF_q16_resp,Response for trial 16,Penn Facial Memory Test
-CPF_q16_ttr,CPF_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test
-CPF_q16_corr,CPF_q16_corr,Response correct for trial 16,Penn Facial Memory Test
-CPF_q17_resp,CPF_q17_resp,Response for trial 17,Penn Facial Memory Test
-CPF_q17_ttr,CPF_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test
-CPF_q17_corr,CPF_q17_corr,Response correct for trial 17,Penn Facial Memory Test
-CPF_q18_resp,CPF_q18_resp,Response for trial 18,Penn Facial Memory Test
-CPF_q18_ttr,CPF_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test
-CPF_q18_corr,CPF_q18_corr,Response correct for trial 18,Penn Facial Memory Test
-CPF_q19_resp,CPF_q19_resp,Response for trial 19,Penn Facial Memory Test
-CPF_q19_ttr,CPF_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test
-CPF_q19_corr,CPF_q19_corr,Response correct for trial 19,Penn Facial Memory Test
-CPF_q20_resp,CPF_q20_resp,Response for trial 20,Penn Facial Memory Test
-CPF_q20_ttr,CPF_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test
-CPF_q20_corr,CPF_q20_corr,Response correct for trial 20,Penn Facial Memory Test
-CPF_q21_resp,CPF_q21_resp,Response for trial 21,Penn Facial Memory Test
-CPF_q21_ttr,CPF_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test
-CPF_q21_corr,CPF_q21_corr,Response correct for trial 21,Penn Facial Memory Test
-CPF_q22_resp,CPF_q22_resp,Response for trial 22,Penn Facial Memory Test
-CPF_q22_ttr,CPF_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test
-CPF_q22_corr,CPF_q22_corr,Response correct for trial 22,Penn Facial Memory Test
-CPF_q23_resp,CPF_q23_resp,Response for trial 23,Penn Facial Memory Test
-CPF_q23_ttr,CPF_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test
-CPF_q23_corr,CPF_q23_corr,Response correct for trial 23,Penn Facial Memory Test
-CPF_q24_resp,CPF_q24_resp,Response for trial 24,Penn Facial Memory Test
-CPF_q24_ttr,CPF_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test
-CPF_q24_corr,CPF_q24_corr,Response correct for trial 24,Penn Facial Memory Test
-CPF_q25_resp,CPF_q25_resp,Response for trial 25,Penn Facial Memory Test
-CPF_q25_ttr,CPF_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test
-CPF_q25_corr,CPF_q25_corr,Response correct for trial 25,Penn Facial Memory Test
-CPF_q26_resp,CPF_q26_resp,Response for trial 26,Penn Facial Memory Test
-CPF_q26_ttr,CPF_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test
-CPF_q26_corr,CPF_q26_corr,Response correct for trial 26,Penn Facial Memory Test
-CPF_q27_resp,CPF_q27_resp,Response for trial 27,Penn Facial Memory Test
-CPF_q27_ttr,CPF_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test
-CPF_q27_corr,CPF_q27_corr,Response correct for trial 27,Penn Facial Memory Test
-CPF_q28_resp,CPF_q28_resp,Response for trial 28,Penn Facial Memory Test
-CPF_q28_ttr,CPF_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test
-CPF_q28_corr,CPF_q28_corr,Response correct for trial 28,Penn Facial Memory Test
-CPF_q29_resp,CPF_q29_resp,Response for trial 29,Penn Facial Memory Test
-CPF_q29_ttr,CPF_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test
-CPF_q29_corr,CPF_q29_corr,Response correct for trial 29,Penn Facial Memory Test
-CPF_q30_resp,CPF_q30_resp,Response for trial 30,Penn Facial Memory Test
-CPF_q30_ttr,CPF_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test
-CPF_q30_corr,CPF_q30_corr,Response correct for trial 30,Penn Facial Memory Test
-CPF_q31_resp,CPF_q31_resp,Response for trial 31,Penn Facial Memory Test
-CPF_q31_ttr,CPF_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test
-CPF_q31_corr,CPF_q31_corr,Response correct for trial 31,Penn Facial Memory Test
-CPF_q32_resp,CPF_q32_resp,Response for trial 32,Penn Facial Memory Test
-CPF_q32_ttr,CPF_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test
-CPF_q32_corr,CPF_q32_corr,Response correct for trial 32,Penn Facial Memory Test
-CPF_q33_resp,CPF_q33_resp,Response for trial 33,Penn Facial Memory Test
-CPF_q33_ttr,CPF_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test
-CPF_q33_corr,CPF_q33_corr,Response correct for trial 33,Penn Facial Memory Test
-CPF_q34_resp,CPF_q34_resp,Response for trial 34,Penn Facial Memory Test
-CPF_q34_ttr,CPF_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test
-CPF_q34_corr,CPF_q34_corr,Response correct for trial 34,Penn Facial Memory Test
-CPF_q35_resp,CPF_q35_resp,Response for trial 35,Penn Facial Memory Test
-CPF_q35_ttr,CPF_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test
-CPF_q35_corr,CPF_q35_corr,Response correct for trial 35,Penn Facial Memory Test
-CPF_q36_resp,CPF_q36_resp,Response for trial 36,Penn Facial Memory Test
-CPF_q36_ttr,CPF_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test
-CPF_q36_corr,CPF_q36_corr,Response correct for trial 36,Penn Facial Memory Test
-CPF_q37_resp,CPF_q37_resp,Response for trial 37,Penn Facial Memory Test
-CPF_q37_ttr,CPF_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test
-CPF_q37_corr,CPF_q37_corr,Response correct for trial 37,Penn Facial Memory Test
-CPF_q38_resp,CPF_q38_resp,Response for trial 38,Penn Facial Memory Test
-CPF_q38_ttr,CPF_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test
-CPF_q38_corr,CPF_q38_corr,Response correct for trial 38,Penn Facial Memory Test
-CPF_q39_resp,CPF_q39_resp,Response for trial 39,Penn Facial Memory Test
-CPF_q39_ttr,CPF_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test
-CPF_q39_corr,CPF_q39_corr,Response correct for trial 39,Penn Facial Memory Test
-CPF_q40_resp,CPF_q40_resp,Response for trial 40,Penn Facial Memory Test
-CPF_q40_ttr,CPF_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test
-CPF_q40_corr,CPF_q40_corr,Response correct for trial 40,Penn Facial Memory Test
-CPFD_A_ScorVers,CPFD_Scorvers,Current Programming Version of the Scoring Code,Penn Facial Memory Test - Delayed Version
+CPF_A_CPF_trial000001_resp,CPF_q1_resp,Response for trial 1,Penn Facial Memory Test
+CPF_A_CPF_trial000001_ttr,CPF_q1_ttr,Time to respond (ms) for trial 1,Penn Facial Memory Test
+CPF_A_CPF_trial000001_corr,CPF_q1_corr,Response correct for trial 1,Penn Facial Memory Test
+CPF_A_CPF_trial000002_resp,CPF_q2_resp,Response for trial 2,Penn Facial Memory Test
+CPF_A_CPF_trial000002_ttr,CPF_q2_ttr,Time to respond (ms) for trial 2,Penn Facial Memory Test
+CPF_A_CPF_trial000002_corr,CPF_q2_corr,Response correct for trial 2,Penn Facial Memory Test
+CPF_A_CPF_trial000003_resp,CPF_q3_resp,Response for trial 3,Penn Facial Memory Test
+CPF_A_CPF_trial000003_ttr,CPF_q3_ttr,Time to respond (ms) for trial 3,Penn Facial Memory Test
+CPF_A_CPF_trial000003_corr,CPF_q3_corr,Response correct for trial 3,Penn Facial Memory Test
+CPF_A_CPF_trial000004_resp,CPF_q4_resp,Response for trial 4,Penn Facial Memory Test
+CPF_A_CPF_trial000004_ttr,CPF_q4_ttr,Time to respond (ms) for trial 4,Penn Facial Memory Test
+CPF_A_CPF_trial000004_corr,CPF_q4_corr,Response correct for trial 4,Penn Facial Memory Test
+CPF_A_CPF_trial000005_resp,CPF_q5_resp,Response for trial 5,Penn Facial Memory Test
+CPF_A_CPF_trial000005_ttr,CPF_q5_ttr,Time to respond (ms) for trial 5,Penn Facial Memory Test
+CPF_A_CPF_trial000005_corr,CPF_q5_corr,Response correct for trial 5,Penn Facial Memory Test
+CPF_A_CPF_trial000006_resp,CPF_q6_resp,Response for trial 6,Penn Facial Memory Test
+CPF_A_CPF_trial000006_ttr,CPF_q6_ttr,Time to respond (ms) for trial 6,Penn Facial Memory Test
+CPF_A_CPF_trial000006_corr,CPF_q6_corr,Response correct for trial 6,Penn Facial Memory Test
+CPF_A_CPF_trial000007_resp,CPF_q7_resp,Response for trial 7,Penn Facial Memory Test
+CPF_A_CPF_trial000007_ttr,CPF_q7_ttr,Time to respond (ms) for trial 7,Penn Facial Memory Test
+CPF_A_CPF_trial000007_corr,CPF_q7_corr,Response correct for trial 7,Penn Facial Memory Test
+CPF_A_CPF_trial000008_resp,CPF_q8_resp,Response for trial 8,Penn Facial Memory Test
+CPF_A_CPF_trial000008_ttr,CPF_q8_ttr,Time to respond (ms) for trial 8,Penn Facial Memory Test
+CPF_A_CPF_trial000008_corr,CPF_q8_corr,Response correct for trial 8,Penn Facial Memory Test
+CPF_A_CPF_trial000009_resp,CPF_q9_resp,Response for trial 9,Penn Facial Memory Test
+CPF_A_CPF_trial000009_ttr,CPF_q9_ttr,Time to respond (ms) for trial 9,Penn Facial Memory Test
+CPF_A_CPF_trial000009_corr,CPF_q9_corr,Response correct for trial 9,Penn Facial Memory Test
+CPF_A_CPF_trial000010_resp,CPF_q10_resp,Response for trial 10,Penn Facial Memory Test
+CPF_A_CPF_trial000010_ttr,CPF_q10_ttr,Time to respond (ms) for trial 10,Penn Facial Memory Test
+CPF_A_CPF_trial000010_corr,CPF_q10_corr,Response correct for trial 10,Penn Facial Memory Test
+CPF_A_CPF_trial000011_resp,CPF_q11_resp,Response for trial 11,Penn Facial Memory Test
+CPF_A_CPF_trial000011_ttr,CPF_q11_ttr,Time to respond (ms) for trial 11,Penn Facial Memory Test
+CPF_A_CPF_trial000011_corr,CPF_q11_corr,Response correct for trial 11,Penn Facial Memory Test
+CPF_A_CPF_trial000012_resp,CPF_q12_resp,Response for trial 12,Penn Facial Memory Test
+CPF_A_CPF_trial000012_ttr,CPF_q12_ttr,Time to respond (ms) for trial 12,Penn Facial Memory Test
+CPF_A_CPF_trial000012_corr,CPF_q12_corr,Response correct for trial 12,Penn Facial Memory Test
+CPF_A_CPF_trial000013_resp,CPF_q13_resp,Response for trial 13,Penn Facial Memory Test
+CPF_A_CPF_trial000013_ttr,CPF_q13_ttr,Time to respond (ms) for trial 13,Penn Facial Memory Test
+CPF_A_CPF_trial000013_corr,CPF_q13_corr,Response correct for trial 13,Penn Facial Memory Test
+CPF_A_CPF_trial000014_resp,CPF_q14_resp,Response for trial 14,Penn Facial Memory Test
+CPF_A_CPF_trial000014_ttr,CPF_q14_ttr,Time to respond (ms) for trial 14,Penn Facial Memory Test
+CPF_A_CPF_trial000014_corr,CPF_q14_corr,Response correct for trial 14,Penn Facial Memory Test
+CPF_A_CPF_trial000015_resp,CPF_q15_resp,Response for trial 15,Penn Facial Memory Test
+CPF_A_CPF_trial000015_ttr,CPF_q15_ttr,Time to respond (ms) for trial 15,Penn Facial Memory Test
+CPF_A_CPF_trial000015_corr,CPF_q15_corr,Response correct for trial 15,Penn Facial Memory Test
+CPF_A_CPF_trial000016_resp,CPF_q16_resp,Response for trial 16,Penn Facial Memory Test
+CPF_A_CPF_trial000016_ttr,CPF_q16_ttr,Time to respond (ms) for trial 16,Penn Facial Memory Test
+CPF_A_CPF_trial000016_corr,CPF_q16_corr,Response correct for trial 16,Penn Facial Memory Test
+CPF_A_CPF_trial000017_resp,CPF_q17_resp,Response for trial 17,Penn Facial Memory Test
+CPF_A_CPF_trial000017_ttr,CPF_q17_ttr,Time to respond (ms) for trial 17,Penn Facial Memory Test
+CPF_A_CPF_trial000017_corr,CPF_q17_corr,Response correct for trial 17,Penn Facial Memory Test
+CPF_A_CPF_trial000018_resp,CPF_q18_resp,Response for trial 18,Penn Facial Memory Test
+CPF_A_CPF_trial000018_ttr,CPF_q18_ttr,Time to respond (ms) for trial 18,Penn Facial Memory Test
+CPF_A_CPF_trial000018_corr,CPF_q18_corr,Response correct for trial 18,Penn Facial Memory Test
+CPF_A_CPF_trial000019_resp,CPF_q19_resp,Response for trial 19,Penn Facial Memory Test
+CPF_A_CPF_trial000019_ttr,CPF_q19_ttr,Time to respond (ms) for trial 19,Penn Facial Memory Test
+CPF_A_CPF_trial000019_corr,CPF_q19_corr,Response correct for trial 19,Penn Facial Memory Test
+CPF_A_CPF_trial000020_resp,CPF_q20_resp,Response for trial 20,Penn Facial Memory Test
+CPF_A_CPF_trial000020_ttr,CPF_q20_ttr,Time to respond (ms) for trial 20,Penn Facial Memory Test
+CPF_A_CPF_trial000020_corr,CPF_q20_corr,Response correct for trial 20,Penn Facial Memory Test
+CPF_A_CPF_trial000021_resp,CPF_q21_resp,Response for trial 21,Penn Facial Memory Test
+CPF_A_CPF_trial000021_ttr,CPF_q21_ttr,Time to respond (ms) for trial 21,Penn Facial Memory Test
+CPF_A_CPF_trial000021_corr,CPF_q21_corr,Response correct for trial 21,Penn Facial Memory Test
+CPF_A_CPF_trial000022_resp,CPF_q22_resp,Response for trial 22,Penn Facial Memory Test
+CPF_A_CPF_trial000022_ttr,CPF_q22_ttr,Time to respond (ms) for trial 22,Penn Facial Memory Test
+CPF_A_CPF_trial000022_corr,CPF_q22_corr,Response correct for trial 22,Penn Facial Memory Test
+CPF_A_CPF_trial000023_resp,CPF_q23_resp,Response for trial 23,Penn Facial Memory Test
+CPF_A_CPF_trial000023_ttr,CPF_q23_ttr,Time to respond (ms) for trial 23,Penn Facial Memory Test
+CPF_A_CPF_trial000023_corr,CPF_q23_corr,Response correct for trial 23,Penn Facial Memory Test
+CPF_A_CPF_trial000024_resp,CPF_q24_resp,Response for trial 24,Penn Facial Memory Test
+CPF_A_CPF_trial000024_ttr,CPF_q24_ttr,Time to respond (ms) for trial 24,Penn Facial Memory Test
+CPF_A_CPF_trial000024_corr,CPF_q24_corr,Response correct for trial 24,Penn Facial Memory Test
+CPF_A_CPF_trial000025_resp,CPF_q25_resp,Response for trial 25,Penn Facial Memory Test
+CPF_A_CPF_trial000025_ttr,CPF_q25_ttr,Time to respond (ms) for trial 25,Penn Facial Memory Test
+CPF_A_CPF_trial000025_corr,CPF_q25_corr,Response correct for trial 25,Penn Facial Memory Test
+CPF_A_CPF_trial000026_resp,CPF_q26_resp,Response for trial 26,Penn Facial Memory Test
+CPF_A_CPF_trial000026_ttr,CPF_q26_ttr,Time to respond (ms) for trial 26,Penn Facial Memory Test
+CPF_A_CPF_trial000026_corr,CPF_q26_corr,Response correct for trial 26,Penn Facial Memory Test
+CPF_A_CPF_trial000027_resp,CPF_q27_resp,Response for trial 27,Penn Facial Memory Test
+CPF_A_CPF_trial000027_ttr,CPF_q27_ttr,Time to respond (ms) for trial 27,Penn Facial Memory Test
+CPF_A_CPF_trial000027_corr,CPF_q27_corr,Response correct for trial 27,Penn Facial Memory Test
+CPF_A_CPF_trial000028_resp,CPF_q28_resp,Response for trial 28,Penn Facial Memory Test
+CPF_A_CPF_trial000028_ttr,CPF_q28_ttr,Time to respond (ms) for trial 28,Penn Facial Memory Test
+CPF_A_CPF_trial000028_corr,CPF_q28_corr,Response correct for trial 28,Penn Facial Memory Test
+CPF_A_CPF_trial000029_resp,CPF_q29_resp,Response for trial 29,Penn Facial Memory Test
+CPF_A_CPF_trial000029_ttr,CPF_q29_ttr,Time to respond (ms) for trial 29,Penn Facial Memory Test
+CPF_A_CPF_trial000029_corr,CPF_q29_corr,Response correct for trial 29,Penn Facial Memory Test
+CPF_A_CPF_trial000030_resp,CPF_q30_resp,Response for trial 30,Penn Facial Memory Test
+CPF_A_CPF_trial000030_ttr,CPF_q30_ttr,Time to respond (ms) for trial 30,Penn Facial Memory Test
+CPF_A_CPF_trial000030_corr,CPF_q30_corr,Response correct for trial 30,Penn Facial Memory Test
+CPF_A_CPF_trial000031_resp,CPF_q31_resp,Response for trial 31,Penn Facial Memory Test
+CPF_A_CPF_trial000031_ttr,CPF_q31_ttr,Time to respond (ms) for trial 31,Penn Facial Memory Test
+CPF_A_CPF_trial000031_corr,CPF_q31_corr,Response correct for trial 31,Penn Facial Memory Test
+CPF_A_CPF_trial000032_resp,CPF_q32_resp,Response for trial 32,Penn Facial Memory Test
+CPF_A_CPF_trial000032_ttr,CPF_q32_ttr,Time to respond (ms) for trial 32,Penn Facial Memory Test
+CPF_A_CPF_trial000032_corr,CPF_q32_corr,Response correct for trial 32,Penn Facial Memory Test
+CPF_A_CPF_trial000033_resp,CPF_q33_resp,Response for trial 33,Penn Facial Memory Test
+CPF_A_CPF_trial000033_ttr,CPF_q33_ttr,Time to respond (ms) for trial 33,Penn Facial Memory Test
+CPF_A_CPF_trial000033_corr,CPF_q33_corr,Response correct for trial 33,Penn Facial Memory Test
+CPF_A_CPF_trial000034_resp,CPF_q34_resp,Response for trial 34,Penn Facial Memory Test
+CPF_A_CPF_trial000034_ttr,CPF_q34_ttr,Time to respond (ms) for trial 34,Penn Facial Memory Test
+CPF_A_CPF_trial000034_corr,CPF_q34_corr,Response correct for trial 34,Penn Facial Memory Test
+CPF_A_CPF_trial000035_resp,CPF_q35_resp,Response for trial 35,Penn Facial Memory Test
+CPF_A_CPF_trial000035_ttr,CPF_q35_ttr,Time to respond (ms) for trial 35,Penn Facial Memory Test
+CPF_A_CPF_trial000035_corr,CPF_q35_corr,Response correct for trial 35,Penn Facial Memory Test
+CPF_A_CPF_trial000036_resp,CPF_q36_resp,Response for trial 36,Penn Facial Memory Test
+CPF_A_CPF_trial000036_ttr,CPF_q36_ttr,Time to respond (ms) for trial 36,Penn Facial Memory Test
+CPF_A_CPF_trial000036_corr,CPF_q36_corr,Response correct for trial 36,Penn Facial Memory Test
+CPF_A_CPF_trial000037_resp,CPF_q37_resp,Response for trial 37,Penn Facial Memory Test
+CPF_A_CPF_trial000037_ttr,CPF_q37_ttr,Time to respond (ms) for trial 37,Penn Facial Memory Test
+CPF_A_CPF_trial000037_corr,CPF_q37_corr,Response correct for trial 37,Penn Facial Memory Test
+CPF_A_CPF_trial000038_resp,CPF_q38_resp,Response for trial 38,Penn Facial Memory Test
+CPF_A_CPF_trial000038_ttr,CPF_q38_ttr,Time to respond (ms) for trial 38,Penn Facial Memory Test
+CPF_A_CPF_trial000038_corr,CPF_q38_corr,Response correct for trial 38,Penn Facial Memory Test
+CPF_A_CPF_trial000039_resp,CPF_q39_resp,Response for trial 39,Penn Facial Memory Test
+CPF_A_CPF_trial000039_ttr,CPF_q39_ttr,Time to respond (ms) for trial 39,Penn Facial Memory Test
+CPF_A_CPF_trial000039_corr,CPF_q39_corr,Response correct for trial 39,Penn Facial Memory Test
+CPF_A_CPF_trial000040_resp,CPF_q40_resp,Response for trial 40,Penn Facial Memory Test
+CPF_A_CPF_trial000040_ttr,CPF_q40_ttr,Time to respond (ms) for trial 40,Penn Facial Memory Test
+CPF_A_CPF_trial000040_corr,CPF_q40_corr,Response correct for trial 40,Penn Facial Memory Test
+CPFD_A_ScorVers,CPFD,Current Programming Version of the Scoring Code,Penn Facial Memory Test - Delayed Version
 CPFD_A_status,CPFD_status,Status Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
 CPFD_A_valid_code,CPFD_valid_code,Valid Code Assigned to CPFD,Penn Facial Memory Test - Delayed Version
 CPFD_A_CPFD_TP,CPFD_CPFDTP,CPFD True Positives,Penn Facial Memory Test - Delayed Version
@@ -366,140 +366,140 @@ CPFD_A_CPFD_TRIAL000040_TTR,CPFD_q40_ttr,Time to respond (ms) for trial 40,Penn 
 CPFD_A_CPFD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Facial Memory Test - Delayed Version
 CPFD_A_CPFD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Facial Memory Test - Delayed Version
 CPFD_A_CPFD_TRIAL000040_CORR,CPFD_q40_corr,Response correct for trial 40,Penn Facial Memory Test - Delayed Version
-CPW_ScorVers,CPW_Scorvers,Current Programming Version of the Scoring Code,Penn Word Memory Test
-CPW_status,CPW_status,Status Code Assigned to CPW,Penn Word Memory Test
-CPW_valid_code,CPW_valid_code,Valid Code Assigned to CPW,Penn Word Memory Test
-CPW_CPWTP,CPW_CPWTP,CPW True Positive Responses,Penn Word Memory Test
-CPW_CPWTN,CPW_CPWTN,CPW True Negative Responses,Penn Word Memory Test
-CPW_CPWFP,CPW_CPWFP,CPW False Positive Responses,Penn Word Memory Test
-CPW_CPWFN,CPW_CPWFN,CPW False Negative Responses,Penn Word Memory Test
-CPW_CPWTPRT,CPW_CPWTPRT,Median Response Time for CPW True Positive Responses (ms),Penn Word Memory Test
-CPW_CPWTNRT,CPW_CPWTNRT,Median Response Time for CPW True Negative Responses (ms),Penn Word Memory Test
-CPW_CPWFPRT,CPW_CPWFPRT,Median Response Time for CPW False Positive Responses (ms),Penn Word Memory Test
-CPW_CPWFNRT,CPW_CPWFNRT,Median Response Time for CPW False Negative Responses (ms),Penn Word Memory Test
+CPW_A_ScorVers,CPW,Current Programming Version of the Scoring Code,Penn Word Memory Test
+CPW_A_status,CPW_status,Status Code Assigned to CPW,Penn Word Memory Test
+CPW_A_valid_code,CPW_valid_code,Valid Code Assigned to CPW,Penn Word Memory Test
+CPW_A_CPW_TP,CPW_CPWTP,CPW True Positive Responses,Penn Word Memory Test
+CPW_A_CPW_TN,CPW_CPWTN,CPW True Negative Responses,Penn Word Memory Test
+CPW_A_CPW_FP,CPW_CPWFP,CPW False Positive Responses,Penn Word Memory Test
+CPW_A_CPW_FN,CPW_CPWFN,CPW False Negative Responses,Penn Word Memory Test
+CPW_A_CPW_TPRT,CPW_CPWTPRT,Median Response Time for CPW True Positive Responses (ms),Penn Word Memory Test
+CPW_A_CPW_TNRT,CPW_CPWTNRT,Median Response Time for CPW True Negative Responses (ms),Penn Word Memory Test
+CPW_A_CPW_FPRT,CPW_CPWFPRT,Median Response Time for CPW False Positive Responses (ms),Penn Word Memory Test
+CPW_A_CPW_FNRT,CPW_CPWFNRT,Median Response Time for CPW False Negative Responses (ms),Penn Word Memory Test
 CPW_IWRD_TOT,CPW_IWRD_TOT,CPW Total Correct Responses,Penn Word Memory Test
 CPW_IWRD_RTC,CPW_IWRD_RTC,Median Response Time for CPW Total Correct Responses (ms),Penn Word Memory Test
-CPW_q1_resp,CPW_q1_resp,Response for trial 1,Penn Word Memory Test
-CPW_q1_ttr,CPW_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test
-CPW_q1_corr,CPW_q1_corr,Response correct for trial 1,Penn Word Memory Test
-CPW_q2_resp,CPW_q2_resp,Response for trial 2,Penn Word Memory Test
-CPW_q2_ttr,CPW_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test
-CPW_q2_corr,CPW_q2_corr,Response correct for trial 2,Penn Word Memory Test
-CPW_q3_resp,CPW_q3_resp,Response for trial 3,Penn Word Memory Test
-CPW_q3_ttr,CPW_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test
-CPW_q3_corr,CPW_q3_corr,Response correct for trial 3,Penn Word Memory Test
-CPW_q4_resp,CPW_q4_resp,Response for trial 4,Penn Word Memory Test
-CPW_q4_ttr,CPW_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test
-CPW_q4_corr,CPW_q4_corr,Response correct for trial 4,Penn Word Memory Test
-CPW_q5_resp,CPW_q5_resp,Response for trial 5,Penn Word Memory Test
-CPW_q5_ttr,CPW_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test
-CPW_q5_corr,CPW_q5_corr,Response correct for trial 5,Penn Word Memory Test
-CPW_q6_resp,CPW_q6_resp,Response for trial 6,Penn Word Memory Test
-CPW_q6_ttr,CPW_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test
-CPW_q6_corr,CPW_q6_corr,Response correct for trial 6,Penn Word Memory Test
-CPW_q7_resp,CPW_q7_resp,Response for trial 7,Penn Word Memory Test
-CPW_q7_ttr,CPW_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test
-CPW_q7_corr,CPW_q7_corr,Response correct for trial 7,Penn Word Memory Test
-CPW_q8_resp,CPW_q8_resp,Response for trial 8,Penn Word Memory Test
-CPW_q8_ttr,CPW_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test
-CPW_q8_corr,CPW_q8_corr,Response correct for trial 8,Penn Word Memory Test
-CPW_q9_resp,CPW_q9_resp,Response for trial 9,Penn Word Memory Test
-CPW_q9_ttr,CPW_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test
-CPW_q9_corr,CPW_q9_corr,Response correct for trial 9,Penn Word Memory Test
-CPW_q10_resp,CPW_q10_resp,Response for trial 10,Penn Word Memory Test
-CPW_q10_ttr,CPW_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test
-CPW_q10_corr,CPW_q10_corr,Response correct for trial 10,Penn Word Memory Test
-CPW_q11_resp,CPW_q11_resp,Response for trial 11,Penn Word Memory Test
-CPW_q11_ttr,CPW_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test
-CPW_q11_corr,CPW_q11_corr,Response correct for trial 11,Penn Word Memory Test
-CPW_q12_resp,CPW_q12_resp,Response for trial 12,Penn Word Memory Test
-CPW_q12_ttr,CPW_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test
-CPW_q12_corr,CPW_q12_corr,Response correct for trial 12,Penn Word Memory Test
-CPW_q13_resp,CPW_q13_resp,Response for trial 13,Penn Word Memory Test
-CPW_q13_ttr,CPW_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test
-CPW_q13_corr,CPW_q13_corr,Response correct for trial 13,Penn Word Memory Test
-CPW_q14_resp,CPW_q14_resp,Response for trial 14,Penn Word Memory Test
-CPW_q14_ttr,CPW_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test
-CPW_q14_corr,CPW_q14_corr,Response correct for trial 14,Penn Word Memory Test
-CPW_q15_resp,CPW_q15_resp,Response for trial 15,Penn Word Memory Test
-CPW_q15_ttr,CPW_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test
-CPW_q15_corr,CPW_q15_corr,Response correct for trial 15,Penn Word Memory Test
-CPW_q16_resp,CPW_q16_resp,Response for trial 16,Penn Word Memory Test
-CPW_q16_ttr,CPW_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test
-CPW_q16_corr,CPW_q16_corr,Response correct for trial 16,Penn Word Memory Test
-CPW_q17_resp,CPW_q17_resp,Response for trial 17,Penn Word Memory Test
-CPW_q17_ttr,CPW_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test
-CPW_q17_corr,CPW_q17_corr,Response correct for trial 17,Penn Word Memory Test
-CPW_q18_resp,CPW_q18_resp,Response for trial 18,Penn Word Memory Test
-CPW_q18_ttr,CPW_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test
-CPW_q18_corr,CPW_q18_corr,Response correct for trial 18,Penn Word Memory Test
-CPW_q19_resp,CPW_q19_resp,Response for trial 19,Penn Word Memory Test
-CPW_q19_ttr,CPW_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test
-CPW_q19_corr,CPW_q19_corr,Response correct for trial 19,Penn Word Memory Test
-CPW_q20_resp,CPW_q20_resp,Response for trial 20,Penn Word Memory Test
-CPW_q20_ttr,CPW_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test
-CPW_q20_corr,CPW_q20_corr,Response correct for trial 20,Penn Word Memory Test
-CPW_q21_resp,CPW_q21_resp,Response for trial 21,Penn Word Memory Test
-CPW_q21_ttr,CPW_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test
-CPW_q21_corr,CPW_q21_corr,Response correct for trial 21,Penn Word Memory Test
-CPW_q22_resp,CPW_q22_resp,Response for trial 22,Penn Word Memory Test
-CPW_q22_ttr,CPW_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test
-CPW_q22_corr,CPW_q22_corr,Response correct for trial 22,Penn Word Memory Test
-CPW_q23_resp,CPW_q23_resp,Response for trial 23,Penn Word Memory Test
-CPW_q23_ttr,CPW_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test
-CPW_q23_corr,CPW_q23_corr,Response correct for trial 23,Penn Word Memory Test
-CPW_q24_resp,CPW_q24_resp,Response for trial 24,Penn Word Memory Test
-CPW_q24_ttr,CPW_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test
-CPW_q24_corr,CPW_q24_corr,Response correct for trial 24,Penn Word Memory Test
-CPW_q25_resp,CPW_q25_resp,Response for trial 25,Penn Word Memory Test
-CPW_q25_ttr,CPW_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test
-CPW_q25_corr,CPW_q25_corr,Response correct for trial 25,Penn Word Memory Test
-CPW_q26_resp,CPW_q26_resp,Response for trial 26,Penn Word Memory Test
-CPW_q26_ttr,CPW_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test
-CPW_q26_corr,CPW_q26_corr,Response correct for trial 26,Penn Word Memory Test
-CPW_q27_resp,CPW_q27_resp,Response for trial 27,Penn Word Memory Test
-CPW_q27_ttr,CPW_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test
-CPW_q27_corr,CPW_q27_corr,Response correct for trial 27,Penn Word Memory Test
-CPW_q28_resp,CPW_q28_resp,Response for trial 28,Penn Word Memory Test
-CPW_q28_ttr,CPW_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test
-CPW_q28_corr,CPW_q28_corr,Response correct for trial 28,Penn Word Memory Test
-CPW_q29_resp,CPW_q29_resp,Response for trial 29,Penn Word Memory Test
-CPW_q29_ttr,CPW_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test
-CPW_q29_corr,CPW_q29_corr,Response correct for trial 29,Penn Word Memory Test
-CPW_q30_resp,CPW_q30_resp,Response for trial 30,Penn Word Memory Test
-CPW_q30_ttr,CPW_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test
-CPW_q30_corr,CPW_q30_corr,Response correct for trial 30,Penn Word Memory Test
-CPW_q31_resp,CPW_q31_resp,Response for trial 31,Penn Word Memory Test
-CPW_q31_ttr,CPW_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test
-CPW_q31_corr,CPW_q31_corr,Response correct for trial 31,Penn Word Memory Test
-CPW_q32_resp,CPW_q32_resp,Response for trial 32,Penn Word Memory Test
-CPW_q32_ttr,CPW_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test
-CPW_q32_corr,CPW_q32_corr,Response correct for trial 32,Penn Word Memory Test
-CPW_q33_resp,CPW_q33_resp,Response for trial 33,Penn Word Memory Test
-CPW_q33_ttr,CPW_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test
-CPW_q33_corr,CPW_q33_corr,Response correct for trial 33,Penn Word Memory Test
-CPW_q34_resp,CPW_q34_resp,Response for trial 34,Penn Word Memory Test
-CPW_q34_ttr,CPW_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test
-CPW_q34_corr,CPW_q34_corr,Response correct for trial 34,Penn Word Memory Test
-CPW_q35_resp,CPW_q35_resp,Response for trial 35,Penn Word Memory Test
-CPW_q35_ttr,CPW_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test
-CPW_q35_corr,CPW_q35_corr,Response correct for trial 35,Penn Word Memory Test
-CPW_q36_resp,CPW_q36_resp,Response for trial 36,Penn Word Memory Test
-CPW_q36_ttr,CPW_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test
-CPW_q36_corr,CPW_q36_corr,Response correct for trial 36,Penn Word Memory Test
-CPW_q37_resp,CPW_q37_resp,Response for trial 37,Penn Word Memory Test
-CPW_q37_ttr,CPW_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test
-CPW_q37_corr,CPW_q37_corr,Response correct for trial 37,Penn Word Memory Test
-CPW_q38_resp,CPW_q38_resp,Response for trial 38,Penn Word Memory Test
-CPW_q38_ttr,CPW_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test
-CPW_q38_corr,CPW_q38_corr,Response correct for trial 38,Penn Word Memory Test
-CPW_q39_resp,CPW_q39_resp,Response for trial 39,Penn Word Memory Test
-CPW_q39_ttr,CPW_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test
-CPW_q39_corr,CPW_q39_corr,Response correct for trial 39,Penn Word Memory Test
-CPW_q40_resp,CPW_q40_resp,Response for trial 40,Penn Word Memory Test
-CPW_q40_ttr,CPW_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test
-CPW_q40_corr,CPW_q40_corr,Response correct for trial 40,Penn Word Memory Test
-CPWD_A_ScorVers,CPWD_Scorvers,Current Programming Version of the Scoring Code,Penn Word Memory Test - Delayed Version
+CPW_A_CPW_trial000001_resp,CPW_q1_resp,Response for trial 1,Penn Word Memory Test
+CPW_A_CPW_trial000001_ttr,CPW_q1_ttr,Time to respond (ms) for trial 1,Penn Word Memory Test
+CPW_A_CPW_trial000001_corr,CPW_q1_corr,Response correct for trial 1,Penn Word Memory Test
+CPW_A_CPW_trial000002_resp,CPW_q2_resp,Response for trial 2,Penn Word Memory Test
+CPW_A_CPW_trial000002_ttr,CPW_q2_ttr,Time to respond (ms) for trial 2,Penn Word Memory Test
+CPW_A_CPW_trial000002_corr,CPW_q2_corr,Response correct for trial 2,Penn Word Memory Test
+CPW_A_CPW_trial000003_resp,CPW_q3_resp,Response for trial 3,Penn Word Memory Test
+CPW_A_CPW_trial000003_ttr,CPW_q3_ttr,Time to respond (ms) for trial 3,Penn Word Memory Test
+CPW_A_CPW_trial000003_corr,CPW_q3_corr,Response correct for trial 3,Penn Word Memory Test
+CPW_A_CPW_trial000004_resp,CPW_q4_resp,Response for trial 4,Penn Word Memory Test
+CPW_A_CPW_trial000004_ttr,CPW_q4_ttr,Time to respond (ms) for trial 4,Penn Word Memory Test
+CPW_A_CPW_trial000004_corr,CPW_q4_corr,Response correct for trial 4,Penn Word Memory Test
+CPW_A_CPW_trial000005_resp,CPW_q5_resp,Response for trial 5,Penn Word Memory Test
+CPW_A_CPW_trial000005_ttr,CPW_q5_ttr,Time to respond (ms) for trial 5,Penn Word Memory Test
+CPW_A_CPW_trial000005_corr,CPW_q5_corr,Response correct for trial 5,Penn Word Memory Test
+CPW_A_CPW_trial000006_resp,CPW_q6_resp,Response for trial 6,Penn Word Memory Test
+CPW_A_CPW_trial000006_ttr,CPW_q6_ttr,Time to respond (ms) for trial 6,Penn Word Memory Test
+CPW_A_CPW_trial000006_corr,CPW_q6_corr,Response correct for trial 6,Penn Word Memory Test
+CPW_A_CPW_trial000007_resp,CPW_q7_resp,Response for trial 7,Penn Word Memory Test
+CPW_A_CPW_trial000007_ttr,CPW_q7_ttr,Time to respond (ms) for trial 7,Penn Word Memory Test
+CPW_A_CPW_trial000007_corr,CPW_q7_corr,Response correct for trial 7,Penn Word Memory Test
+CPW_A_CPW_trial000008_resp,CPW_q8_resp,Response for trial 8,Penn Word Memory Test
+CPW_A_CPW_trial000008_ttr,CPW_q8_ttr,Time to respond (ms) for trial 8,Penn Word Memory Test
+CPW_A_CPW_trial000008_corr,CPW_q8_corr,Response correct for trial 8,Penn Word Memory Test
+CPW_A_CPW_trial000009_resp,CPW_q9_resp,Response for trial 9,Penn Word Memory Test
+CPW_A_CPW_trial000009_ttr,CPW_q9_ttr,Time to respond (ms) for trial 9,Penn Word Memory Test
+CPW_A_CPW_trial000009_corr,CPW_q9_corr,Response correct for trial 9,Penn Word Memory Test
+CPW_A_CPW_trial000010_resp,CPW_q10_resp,Response for trial 10,Penn Word Memory Test
+CPW_A_CPW_trial000010_ttr,CPW_q10_ttr,Time to respond (ms) for trial 10,Penn Word Memory Test
+CPW_A_CPW_trial000010_corr,CPW_q10_corr,Response correct for trial 10,Penn Word Memory Test
+CPW_A_CPW_trial000011_resp,CPW_q11_resp,Response for trial 11,Penn Word Memory Test
+CPW_A_CPW_trial000011_ttr,CPW_q11_ttr,Time to respond (ms) for trial 11,Penn Word Memory Test
+CPW_A_CPW_trial000011_corr,CPW_q11_corr,Response correct for trial 11,Penn Word Memory Test
+CPW_A_CPW_trial000012_resp,CPW_q12_resp,Response for trial 12,Penn Word Memory Test
+CPW_A_CPW_trial000012_ttr,CPW_q12_ttr,Time to respond (ms) for trial 12,Penn Word Memory Test
+CPW_A_CPW_trial000012_corr,CPW_q12_corr,Response correct for trial 12,Penn Word Memory Test
+CPW_A_CPW_trial000013_resp,CPW_q13_resp,Response for trial 13,Penn Word Memory Test
+CPW_A_CPW_trial000013_ttr,CPW_q13_ttr,Time to respond (ms) for trial 13,Penn Word Memory Test
+CPW_A_CPW_trial000013_corr,CPW_q13_corr,Response correct for trial 13,Penn Word Memory Test
+CPW_A_CPW_trial000014_resp,CPW_q14_resp,Response for trial 14,Penn Word Memory Test
+CPW_A_CPW_trial000014_ttr,CPW_q14_ttr,Time to respond (ms) for trial 14,Penn Word Memory Test
+CPW_A_CPW_trial000014_corr,CPW_q14_corr,Response correct for trial 14,Penn Word Memory Test
+CPW_A_CPW_trial000015_resp,CPW_q15_resp,Response for trial 15,Penn Word Memory Test
+CPW_A_CPW_trial000015_ttr,CPW_q15_ttr,Time to respond (ms) for trial 15,Penn Word Memory Test
+CPW_A_CPW_trial000015_corr,CPW_q15_corr,Response correct for trial 15,Penn Word Memory Test
+CPW_A_CPW_trial000016_resp,CPW_q16_resp,Response for trial 16,Penn Word Memory Test
+CPW_A_CPW_trial000016_ttr,CPW_q16_ttr,Time to respond (ms) for trial 16,Penn Word Memory Test
+CPW_A_CPW_trial000016_corr,CPW_q16_corr,Response correct for trial 16,Penn Word Memory Test
+CPW_A_CPW_trial000017_resp,CPW_q17_resp,Response for trial 17,Penn Word Memory Test
+CPW_A_CPW_trial000017_ttr,CPW_q17_ttr,Time to respond (ms) for trial 17,Penn Word Memory Test
+CPW_A_CPW_trial000017_corr,CPW_q17_corr,Response correct for trial 17,Penn Word Memory Test
+CPW_A_CPW_trial000018_resp,CPW_q18_resp,Response for trial 18,Penn Word Memory Test
+CPW_A_CPW_trial000018_ttr,CPW_q18_ttr,Time to respond (ms) for trial 18,Penn Word Memory Test
+CPW_A_CPW_trial000018_corr,CPW_q18_corr,Response correct for trial 18,Penn Word Memory Test
+CPW_A_CPW_trial000019_resp,CPW_q19_resp,Response for trial 19,Penn Word Memory Test
+CPW_A_CPW_trial000019_ttr,CPW_q19_ttr,Time to respond (ms) for trial 19,Penn Word Memory Test
+CPW_A_CPW_trial000019_corr,CPW_q19_corr,Response correct for trial 19,Penn Word Memory Test
+CPW_A_CPW_trial000020_resp,CPW_q20_resp,Response for trial 20,Penn Word Memory Test
+CPW_A_CPW_trial000020_ttr,CPW_q20_ttr,Time to respond (ms) for trial 20,Penn Word Memory Test
+CPW_A_CPW_trial000020_corr,CPW_q20_corr,Response correct for trial 20,Penn Word Memory Test
+CPW_A_CPW_trial000021_resp,CPW_q21_resp,Response for trial 21,Penn Word Memory Test
+CPW_A_CPW_trial000021_ttr,CPW_q21_ttr,Time to respond (ms) for trial 21,Penn Word Memory Test
+CPW_A_CPW_trial000021_corr,CPW_q21_corr,Response correct for trial 21,Penn Word Memory Test
+CPW_A_CPW_trial000022_resp,CPW_q22_resp,Response for trial 22,Penn Word Memory Test
+CPW_A_CPW_trial000022_ttr,CPW_q22_ttr,Time to respond (ms) for trial 22,Penn Word Memory Test
+CPW_A_CPW_trial000022_corr,CPW_q22_corr,Response correct for trial 22,Penn Word Memory Test
+CPW_A_CPW_trial000023_resp,CPW_q23_resp,Response for trial 23,Penn Word Memory Test
+CPW_A_CPW_trial000023_ttr,CPW_q23_ttr,Time to respond (ms) for trial 23,Penn Word Memory Test
+CPW_A_CPW_trial000023_corr,CPW_q23_corr,Response correct for trial 23,Penn Word Memory Test
+CPW_A_CPW_trial000024_resp,CPW_q24_resp,Response for trial 24,Penn Word Memory Test
+CPW_A_CPW_trial000024_ttr,CPW_q24_ttr,Time to respond (ms) for trial 24,Penn Word Memory Test
+CPW_A_CPW_trial000024_corr,CPW_q24_corr,Response correct for trial 24,Penn Word Memory Test
+CPW_A_CPW_trial000025_resp,CPW_q25_resp,Response for trial 25,Penn Word Memory Test
+CPW_A_CPW_trial000025_ttr,CPW_q25_ttr,Time to respond (ms) for trial 25,Penn Word Memory Test
+CPW_A_CPW_trial000025_corr,CPW_q25_corr,Response correct for trial 25,Penn Word Memory Test
+CPW_A_CPW_trial000026_resp,CPW_q26_resp,Response for trial 26,Penn Word Memory Test
+CPW_A_CPW_trial000026_ttr,CPW_q26_ttr,Time to respond (ms) for trial 26,Penn Word Memory Test
+CPW_A_CPW_trial000026_corr,CPW_q26_corr,Response correct for trial 26,Penn Word Memory Test
+CPW_A_CPW_trial000027_resp,CPW_q27_resp,Response for trial 27,Penn Word Memory Test
+CPW_A_CPW_trial000027_ttr,CPW_q27_ttr,Time to respond (ms) for trial 27,Penn Word Memory Test
+CPW_A_CPW_trial000027_corr,CPW_q27_corr,Response correct for trial 27,Penn Word Memory Test
+CPW_A_CPW_trial000028_resp,CPW_q28_resp,Response for trial 28,Penn Word Memory Test
+CPW_A_CPW_trial000028_ttr,CPW_q28_ttr,Time to respond (ms) for trial 28,Penn Word Memory Test
+CPW_A_CPW_trial000028_corr,CPW_q28_corr,Response correct for trial 28,Penn Word Memory Test
+CPW_A_CPW_trial000029_resp,CPW_q29_resp,Response for trial 29,Penn Word Memory Test
+CPW_A_CPW_trial000029_ttr,CPW_q29_ttr,Time to respond (ms) for trial 29,Penn Word Memory Test
+CPW_A_CPW_trial000029_corr,CPW_q29_corr,Response correct for trial 29,Penn Word Memory Test
+CPW_A_CPW_trial000030_resp,CPW_q30_resp,Response for trial 30,Penn Word Memory Test
+CPW_A_CPW_trial000030_ttr,CPW_q30_ttr,Time to respond (ms) for trial 30,Penn Word Memory Test
+CPW_A_CPW_trial000030_corr,CPW_q30_corr,Response correct for trial 30,Penn Word Memory Test
+CPW_A_CPW_trial000031_resp,CPW_q31_resp,Response for trial 31,Penn Word Memory Test
+CPW_A_CPW_trial000031_ttr,CPW_q31_ttr,Time to respond (ms) for trial 31,Penn Word Memory Test
+CPW_A_CPW_trial000031_corr,CPW_q31_corr,Response correct for trial 31,Penn Word Memory Test
+CPW_A_CPW_trial000032_resp,CPW_q32_resp,Response for trial 32,Penn Word Memory Test
+CPW_A_CPW_trial000032_ttr,CPW_q32_ttr,Time to respond (ms) for trial 32,Penn Word Memory Test
+CPW_A_CPW_trial000032_corr,CPW_q32_corr,Response correct for trial 32,Penn Word Memory Test
+CPW_A_CPW_trial000033_resp,CPW_q33_resp,Response for trial 33,Penn Word Memory Test
+CPW_A_CPW_trial000033_ttr,CPW_q33_ttr,Time to respond (ms) for trial 33,Penn Word Memory Test
+CPW_A_CPW_trial000033_corr,CPW_q33_corr,Response correct for trial 33,Penn Word Memory Test
+CPW_A_CPW_trial000034_resp,CPW_q34_resp,Response for trial 34,Penn Word Memory Test
+CPW_A_CPW_trial000034_ttr,CPW_q34_ttr,Time to respond (ms) for trial 34,Penn Word Memory Test
+CPW_A_CPW_trial000034_corr,CPW_q34_corr,Response correct for trial 34,Penn Word Memory Test
+CPW_A_CPW_trial000035_resp,CPW_q35_resp,Response for trial 35,Penn Word Memory Test
+CPW_A_CPW_trial000035_ttr,CPW_q35_ttr,Time to respond (ms) for trial 35,Penn Word Memory Test
+CPW_A_CPW_trial000035_corr,CPW_q35_corr,Response correct for trial 35,Penn Word Memory Test
+CPW_A_CPW_trial000036_resp,CPW_q36_resp,Response for trial 36,Penn Word Memory Test
+CPW_A_CPW_trial000036_ttr,CPW_q36_ttr,Time to respond (ms) for trial 36,Penn Word Memory Test
+CPW_A_CPW_trial000036_corr,CPW_q36_corr,Response correct for trial 36,Penn Word Memory Test
+CPW_A_CPW_trial000037_resp,CPW_q37_resp,Response for trial 37,Penn Word Memory Test
+CPW_A_CPW_trial000037_ttr,CPW_q37_ttr,Time to respond (ms) for trial 37,Penn Word Memory Test
+CPW_A_CPW_trial000037_corr,CPW_q37_corr,Response correct for trial 37,Penn Word Memory Test
+CPW_A_CPW_trial000038_resp,CPW_q38_resp,Response for trial 38,Penn Word Memory Test
+CPW_A_CPW_trial000038_ttr,CPW_q38_ttr,Time to respond (ms) for trial 38,Penn Word Memory Test
+CPW_A_CPW_trial000038_corr,CPW_q38_corr,Response correct for trial 38,Penn Word Memory Test
+CPW_A_CPW_trial000039_resp,CPW_q39_resp,Response for trial 39,Penn Word Memory Test
+CPW_A_CPW_trial000039_ttr,CPW_q39_ttr,Time to respond (ms) for trial 39,Penn Word Memory Test
+CPW_A_CPW_trial000039_corr,CPW_q39_corr,Response correct for trial 39,Penn Word Memory Test
+CPW_A_CPW_trial000040_resp,CPW_q40_resp,Response for trial 40,Penn Word Memory Test
+CPW_A_CPW_trial000040_ttr,CPW_q40_ttr,Time to respond (ms) for trial 40,Penn Word Memory Test
+CPW_A_CPW_trial000040_corr,CPW_q40_corr,Response correct for trial 40,Penn Word Memory Test
+CPWD_A_ScorVers,CPWD,Current Programming Version of the Scoring Code,Penn Word Memory Test - Delayed Version
 CPWD_A_status,CPWD_status,Status Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
 CPWD_A_valid_code,CPWD_valid_code,Valid Code Assigned to CPWD,Penn Word Memory Test - Delayed Version
 CPWD_A_CPWD_TP,CPWD_CPWDTP,CPWD True Positive Responses,Penn Word Memory Test - Delayed Version
@@ -717,13 +717,13 @@ CPWD_A_CPWD_TRIAL000040_TTR,CPWD_q40_ttr,Time to respond (ms) for trial 40,Penn 
 CPWD_A_CPWD_TRIAL000040_TRIAL,,Trial Order of Stimuli Presented,Penn Word Memory Test - Delayed Version
 CPWD_A_CPWD_TRIAL000040_QID,,Question ID for Stimuli Presented,Penn Word Memory Test - Delayed Version
 CPWD_A_CPWD_TRIAL000040_CORR,CPWD_q40_corr,Response correct for trial 40,Penn Word Memory Test - Delayed Version
-MPRACT_ScorVers,MPRACT_Scorvers,Current Programming Version of the Scoring Code,Motor Praxis Test
+MPRACT_ScorVers,MPRACT,Current Programming Version of the Scoring Code,Motor Praxis Test
 MPRACT_status,MPRACT_status,Status Code Assigned to Mouse Praxis ,Motor Praxis Test
 MPRACT_valid_code,MPRACT_valid_code,Valid Code Assigned to Mouse Praxis,Motor Praxis Test
 MPRACT_MP1RT,MPRACT_MP1RT,Median Response Time for Mouse Praxis Trial 1 (ms),Motor Praxis Test
 MPRACT_MP2,MPRACT_MP2,Mouse Praxis Correct Responses Trial 2,Motor Praxis Test
 MPRACT_MP2RTCR,MPRACT_MP2RTCR,Median Response Time for Mouse Praxis Trial 2 Correct Responses (ms),Motor Praxis Test
-PCET_A_ScorVers,PCET_Scorvers,Current Programming Version of the Scoring Code,Penn Conditional Exclusion Test - Form A
+PCET_A_ScorVers,PCET,Current Programming Version of the Scoring Code,Penn Conditional Exclusion Test - Form A
 PCET_A_status,PCET_status,Status Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
 PCET_A_valid_code,PCET_valid_code,Valid Code Assigned to PCET,Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_CR,PCET_PCETCR,PCET Number Correct Responses,Penn Conditional Exclusion Test - Form A
@@ -735,13 +735,13 @@ PCET_A_PCET_WIS_PER_RES,PCET_PER_RES,PCET Perseverative Errors Plus Correct Pers
 PCET_A_PCET_EFF,PCET_PCET_EFF,PCET Efficiency = PCET_ACC/log(PCETRTCR),Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_NUM,PCET_PCET_NUM,Total Number of Trials,Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_CAT,PCET_PCET_CAT,Number of PCET Categories Achieved,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT1_TR,PCET_PCET_CAT1_tr,Number of Trials Required to Achieve Category 1,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT2_TR,PCET_PCET_CAT2_tr,Number of Trials Required to Achieve Category 2,Penn Conditional Exclusion Test - Form A
-PCET_A_PCET_CAT3_TR,PCET_PCET_CAT3_tr,Number of Trials Required to Achieve Category 3,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT1_TR,PCET_CAT1_tr,Number of Trials Required to Achieve Category 1,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT2_TR,PCET_CAT2_tr,Number of Trials Required to Achieve Category 2,Penn Conditional Exclusion Test - Form A
+PCET_A_PCET_CAT3_TR,PCET_CAT3_tr,Number of Trials Required to Achieve Category 3,Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_ACC,PCET_PCET_ACC,PCET Accuracy = PCET_CAT * PCETCR/(PCETCR +PCETER),Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_ACC2,PCET_PCET_ACC2,PECT Accuracy2 = (PCET_CAT+1)*PCETCR/(PCETCR+PCETER),Penn Conditional Exclusion Test - Form A
 PCET_A_PCET_RT,,Median Response Time for All Responses (ms),Penn Conditional Exclusion Test - Form A
-PMAT24_A_ScorVers,PMAT24A_Scorvers,Current Programming Version of the Scoring Code,Penn Matrix Analysis Test - Form A - 24 items
+PMAT24_A_ScorVers,PMAT,Current Programming Version of the Scoring Code,Penn Matrix Analysis Test - Form A - 24 items
 PMAT24_A_PMAT24_A_FORM,PMAT24A_PMAT24_FORM,Form of this administration,Penn Matrix Analysis Test - Form A - 24 items
 PMAT24_A_valid_code,PMAT24A_status,Status Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
 PMAT24_A_PMAT24_A_CR,PMAT24A_valid_code,Valid Code Assigned to PMAT24,Penn Matrix Analysis Test - Form A - 24 items
@@ -870,7 +870,7 @@ PMAT24_A_PMAT24_A_QID000024_TTR,PMAT24A_q24_resp,Time to respond (ms) for trial 
 PMAT24_A_PMAT24_A_QID000024_TRIAL,PMAT24A_q24_ttr,Trial Order of Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
 PMAT24_A_PMAT24_A_QID000024_QID,,Question ID for Stimuli Presented,Penn Matrix Analysis Test - Form A - 24 items
 PMAT24_A_PMAT24_A_QID000024_CORR,PMAT24A_q24_corr,Response correct for trial 24,Penn Matrix Analysis Test - Form A - 24 items
-PVOC_ScorVers,PVOC_Scorvers,Current Programming Version of the Scoring Code,Penn Vocabulary Test
+PVOC_ScorVers,PVOC_ScorVers,Current Programming Version of the Scoring Code,Penn Vocabulary Test
 PVOC_status,PVOC_status,Status Code Assigned to PVOC,Penn Vocabulary Test
 PVOC_valid_code,PVOC_valid_code,Valid Code Assigned to PVOC,Penn Vocabulary Test
 PVOC_PVOC1,PVOC_PVOC1,PVOC Correct Responses for Items 1-10,Penn Vocabulary Test
@@ -949,33 +949,33 @@ PVOC_RES_47,PVOC_RES_47,Response for Item 47,Penn Vocabulary Test
 PVOC_RES_48,PVOC_RES_48,Response for Item 48,Penn Vocabulary Test
 PVOC_RES_49,PVOC_RES_49,Response for Item 49,Penn Vocabulary Test
 PVOC_RES_50,PVOC_RES_50,Response for Item 50,Penn Vocabulary Test
-PVRT_ScorVers,SPVRT_Scorvers,Current Programming Version of the Scoring Code,Penn Logical Reasoning Test - Short Version
-PVRT_status,PVRT_form,Form of the PVRT,Penn Logical Reasoning Test - Short Version
-PVRT_valid_code,PVRT_status,Status Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
-PVRT_PVRT_FORM,PVRT_valid_code,Valid Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_ScorVers,SPVRT,Current Programming Version of the Scoring Code,Penn Logical Reasoning Test - Short Version
+PVRT_PVRT_Form,PVRT_form,Form of the PVRT,Penn Logical Reasoning Test - Short Version
+PVRT_Status,PVRT_status,Status Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
+PVRT_valid_code,PVRT_valid_code,Valid Code Assigned to SPVRT,Penn Logical Reasoning Test - Short Version
 PVRT_PVRTCR,PVRT_PVRTCR,Correct Responses for SPVRT,Penn Logical Reasoning Test - Short Version
 PVRT_PVRT_PC,PVRT_PVRT_PC,Percent Correct for SPVRT,Penn Logical Reasoning Test - Short Version
 PVRT_PVRTRTTO,PVRT_PVRTRTTO,All Responses Median Response Time (ms) for SPVRT,Penn Logical Reasoning Test - Short Version
 PVRT_PVRTRTCR,PVRT_PVRTRTCR,SPVRT Median Response Time for Correct Responses (ms),Penn Logical Reasoning Test - Short Version
 PVRT_PVRTRTER,PVRT_PVRTRTER,SPVRT Median Response Time for Incorrect Responses (ms),Penn Logical Reasoning Test - Short Version
 PVRT_PVRT_EFF,PVRT_PVRT_EFF,PVRT Efficiency = PVRT_PC/log(PVRTRTCR),Penn Logical Reasoning Test - Short Version
-SHORTVOLT_ScorVers,SVOLT_Scorvers,Current Programming Version of the Scoring Code,Visual Object Learning Test - Short Version
-SHORTVOLT_status,SHORTVOLT_status,Status Code Assigned to SVOLT,Visual Object Learning Test - Short Version
-SHORTVOLT_valid_code,SHORTVOLT_valid_code,Valid Code Assigned to SVOLT,Visual Object Learning Test - Short Version
-SHORTVOLT_SVT,SHORTVOLT_SVT,SVOLT Total Correct,Visual Object Learning Test - Short Version
-SHORTVOLT_SVTRT,SHORTVOLT_SVTRT,Median Response Time for Short VOLT All Responses (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTCRT,SHORTVOLT_SVTCRT,Median Response Time for SVOLT Correct Responses (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTIRT,SHORTVOLT_SVTIRT,Median Response Time for SVOLT Incorrect Responses (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTTP,SHORTVOLT_SVTTP,SVOLT True Positive Responses,Visual Object Learning Test - Short Version
-SHORTVOLT_SVTTN,SHORTVOLT_SVTTN,SVOLT True Negative Responses,Visual Object Learning Test - Short Version
-SHORTVOLT_SVTFP,SHORTVOLT_SVTFP,SVOLT False Positive Responses,Visual Object Learning Test - Short Version
-SHORTVOLT_SVTFN,SHORTVOLT_SVTFN,SVOLT False Negative Responses,Visual Object Learning Test - Short Version
-SHORTVOLT_SVTTPRT,SHORTVOLT_SVTTPRT,SVOLT True Positive Median Response Time (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTTNRT,SHORTVOLT_SVTTNRT,SVOLT True Negative Median Response Time (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTFPRT,SHORTVOLT_SVTFPRT,SVOLT False Positive Median Response Time (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVTFNRT,SHORTVOLT_SVTFNRT,SVOLT False Negative Median Response Time (ms),Visual Object Learning Test - Short Version
-SHORTVOLT_SVT_EFF,SHORTVOLT_SVT_EFF,Short VOLT Efficiency ,Visual Object Learning Test - Short Version
-SPCPTNL_ScorVers,SPCPTNL_test,Current Programming Version of the Scoring Code,Short Penn Continuous Performance Task - Number Letter Version
+SVOLT_A_ScorVers,SVOLT,Current Programming Version of the Scoring Code,Visual Object Learning Test - Short Version
+SVOLT_A_status,SHORTVOLT_status,Status Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SVOLT_A_valid_code,SHORTVOLT_valid_code,Valid Code Assigned to SVOLT,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_CR,SHORTVOLT_SVT,SVOLT Total Correct,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_RT,SHORTVOLT_SVTRT,Median Response Time for Short VOLT All Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_CRT,SHORTVOLT_SVTCRT,Median Response Time for SVOLT Correct Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_IRT,SHORTVOLT_SVTIRT,Median Response Time for SVOLT Incorrect Responses (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TP,SHORTVOLT_SVTTP,SVOLT True Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TN,SHORTVOLT_SVTTN,SVOLT True Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FP,SHORTVOLT_SVTFP,SVOLT False Positive Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FN,SHORTVOLT_SVTFN,SVOLT False Negative Responses,Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TPRT,SHORTVOLT_SVTTPRT,SVOLT True Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_TNRT,SHORTVOLT_SVTTNRT,SVOLT True Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FPRT,SHORTVOLT_SVTFPRT,SVOLT False Positive Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_FNRT,SHORTVOLT_SVTFNRT,SVOLT False Negative Median Response Time (ms),Visual Object Learning Test - Short Version
+SVOLT_A_SVOLT_EFF,SHORTVOLT_SVT_EFF,Short VOLT Efficiency ,Visual Object Learning Test - Short Version
+SPCPTNL_ScorVers,SPCPTNL,Current Programming Version of the Scoring Code,Short Penn Continuous Performance Task - Number Letter Version
 SPCPTNL_status,SPCPTNL_status,Status Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
 SPCPTNL_valid_code,SPCPTNL_valid_code,Valid Code Assigned to SPCPTNL,Short Penn Continuous Performance Task - Number Letter Version
 SPCPTNL_SCPN_TP,SPCPTNL_SCPN_TP,NumLet True Positive Responses for Number Trials,Short Penn Continuous Performance Task - Number Letter Version
@@ -1003,7 +1003,7 @@ SPCPTNL_SCPT_SEN,,Sensitivity = SCPT_TP/(SCPT_TP + SCPT_FN),Short Penn Continuou
 SPCPTNL_SCPT_SPEC,,Specificity = SCPT_TN/(SCPT_TN + SCPT_FP),Short Penn Continuous Performance Task - Number Letter Version
 SPCPTNL_SCPT_LRNR,SPCPTNL_SCPT_LRNR,NumLet CPT Longest Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
 SPCPTNL_SCPT_FRNR,SPCPTNL_SCPT_FRNR,NumLet CPT Final Run of Non-Responses,Short Penn Continuous Performance Task - Number Letter Version
-SVOLTD_A_ScorVers,SVOLTD_Scorvers,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
+SVOLTD_A_ScorVers,SVOLTD,Current Programming Version of the Scoring Code,Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_status,SVDELAY_status,Status Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_valid_code,SVDELAY_valid_code,Valid Code Assigned to SVOLTD,Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_SVT_LD,SVDELAY_SVT_LD,SVOLTD Total Correct,Visual Object Learning Test - Delayed Short Version
@@ -1018,7 +1018,7 @@ SVOLTD_A_SVT_LDTNRT,SVDELAY_SVT_LDTNRT,SVOLTD True Negative Median Response Time
 SVOLTD_A_SVT_LDFPRT,SVDELAY_SVT_LDFPRT,SVOLTD False Positive Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_SVT_LDFNRT,SVDELAY_SVT_LDFNRT,SVOLTD False Negative Median Response Time (ms),Visual Object Learning Test - Delayed Short Version
 SVOLTD_A_SVT_EFFD,SVDELAY_SVT_EFFD,Short VOLT Delay Efficiency,Visual Object Learning Test - Delayed Short Version
-SFNB2_ScorVers,SFNB2_Scorvers,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
+SFNB2_ScorVers,SFNB2,Current Programming Version of the Scoring Code,Short Fractal-N-Back- 2 Back Version
 SFNB2_status,SFNB2_status,SFNB2 completion status,Short Fractal-N-Back- 2 Back Version
 SFNB2_valid_code,SFNB2_valid_code,SFNB2 valid code,Short Fractal-N-Back- 2 Back Version
 SFNB2_SFNB_TP,SFNB2_SFNB_TP,SFNB2 True Positive Responses,Short Fractal-N-Back- 2 Back Version
@@ -1040,11 +1040,11 @@ SFNB2_SFNB_FN2,SFNB2_SFNB_FN2,SFNB2 False Negative Responses for 2-Back Trials,S
 SFNB2_SFNB_RTC2,SFNB2_SFNB_RTC2,SFNB2 Median Response Time for Correct 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
 SFNB2_SFNB_MCR,SFNB2_SFNB_MCR,SFNB2 True Positive Reponses for 1-Back and 2-Back Trials,Short Fractal-N-Back- 2 Back Version
 SFNB2_SFNB_MRTC,SFNB2_SFNB_MRTC,SFNB2 Mean of Median RT for True Positive Responses for 1-Back and for 2-Back Trials (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MRT,,SFNB2 Median Response Time for All Responses (ms),Short Fractal-N-Back- 2 Back Version
-SFNB2_SFNB_MEFF,,SFNB2 Efficiency = SFNB_MCR/log(SFNB_MRTC),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MRT,SFNB2_SFNB_MRT,SFNB2 Median Response Time for All Responses (ms),Short Fractal-N-Back- 2 Back Version
+SFNB2_SFNB_MEFF,SFNB2_SFNB_MEFF,SFNB2 Efficiency = SFNB_MCR/log(SFNB_MRTC),Short Fractal-N-Back- 2 Back Version
 SFNB2_SFNB_MSEN,,SFNB2 Sensitivity = (SFNB_TP1 + SFNB_TP2)/(SFNB_TP1 + SFNB_TP2 +SFNB_FN1 + SFNB_FN2),Short Fractal-N-Back- 2 Back Version
 SFNB2_SFNB_MSPEC,,SFNB2 Specificity = (SFNB_TN1 + SFNB_TN2)/(SFNB_TN1 + SFNB_TN2 +SFNB_FP1 + SFNB_FP2),Short Fractal-N-Back- 2 Back Version
-ER40_D_ScorVers,ER40D_Scorvers,Current Programming Version of the Scoring Code,Emotion Recognition Task- Form D- 40 items 
+ER40_D_ScorVers,ER40D,Current Programming Version of the Scoring Code,Emotion Recognition Task- Form D- 40 items 
 ER40_D_status,ER40D_status,ER40 completion status,Emotion Recognition Task- Form D- 40 items 
 ER40_D_valid_code,ER40D_valid_code,ER40 valid code,Emotion Recognition Task- Form D- 40 items 
 ER40_D_ER40D_CR,ER40D_ER40_CR,ER40 Correct Responses,Emotion Recognition Task- Form D- 40 items 
@@ -1110,7 +1110,7 @@ ER40_D_ER40D_OTHCR,ER40D_ER40OTHCR,ER40 Correct Identifications of Other Race fa
 ER40_D_ER40D_CACRT,ER40D_ER40CACRT,ER40 Median Response Time for Correct Identifications of Caucasian faces (ms),Emotion Recognition Task- Form D- 40 items 
 ER40_D_ER40D_AACRT,ER40D_ER40AACRT,ER40 Median Response Time for Correct Identifications of African American faces (ms),Emotion Recognition Task- Form D- 40 items 
 ER40_D_ER40D_OTHCRT,ER40D_ER40OTHCRT,ER40 Median Response Time for Correct Identifications of Other Race faces (ms),Emotion Recognition Task- Form D- 40 items 
-MEDF36_A_ScorVers,MEDF36_Scorvers,Current Programming Version of the Scoring Code,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_ScorVers,MEDF36,Current Programming Version of the Scoring Code,Measured Emotion Differentiation Task- 36 items
 MEDF36_A_status,MEDF36_status,MEDF36 completion status,Measured Emotion Differentiation Task- 36 items
 MEDF36_A_valid_code,MEDF36_valid_code,MEDF36 valid code,Measured Emotion Differentiation Task- 36 items
 MEDF36_A_MEDF36A_CR,MEDF36_MEDF36_A,Total Correct Measured Emodiff Trials,Measured Emotion Differentiation Task- 36 items
@@ -1156,6 +1156,5 @@ MEDF36_A_MEDF36A_SAD_CR,MEDF36_MEDF36_SAD_CR,Correct Responses for Measured Emod
 MEDF36_A_MEDF36A_SAD_RTCR,MEDF36_MEDF36_SAD_RTCR,Median Response Time for Correct Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
 MEDF36_A_MEDF36A_SAD_ER,,Total Incorrect Sad Trial Responses,Measured Emotion Differentiation Task- 36 items
 MEDF36_A_MEDF36A_SAD_RTER,MEDF36_MEDF36_SAD_RTER,Median Response Time for Incorrect Measured Emodiff Sad Trials (ms),Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAME_CR,,Total Incorrect Anger Same (No Difference) Responses,Measured Emotion Differentiation Task- 36 items
-MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_CR,Correct Responses for Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items
+MEDF36_A_MEDF36A_SAME_CR,MEDF36_MEDF36_SAME_CR,Total Incorrect Anger Same (No Difference) Responses,Measured Emotion Differentiation Task- 36 items
 MEDF36_A_MEDF36A_SAME_RTCR,MEDF36_MEDF36_SAME_RTCR,Median Response Time for Correct Measured Emodiff No Difference Trials,Measured Emotion Differentiation Task- 36 items

--- a/scripts/import/webcnp/csv2redcap
+++ b/scripts/import/webcnp/csv2redcap
@@ -12,7 +12,7 @@ import string
 import os
 import hashlib
 
-import pandas
+import pandas as pd
 import sys
 
 import cnp
@@ -63,13 +63,37 @@ if not redcap:
         print("ERROR:Could not connect to redcap server!")
     sys.exit(1)
 
-
 # Read input file
-data = pandas.io.parsers.read_csv( args.infile )
+data = pd.read_csv(args.infile)
 
 # Replace periods in column labels with underscores
-data.rename( columns = lambda s: s.replace( '.', '_' ).lower(), inplace=True )
+data.rename(columns=lambda s: s.replace('.', '_').lower(), inplace=True)
 
+## New Survey->Evioni renames
+# Store current varnames for reference
+_current_varnames = [x['field_name'] for x in redcap.metadata]
+
+renames = pd.read_csv('NCANDA_Survey_Codebook.csv')
+for _var in ['survey_var', 'evioni_var']:  # fit the previous data file rename
+    renames[_var] = renames[_var].str.lower()
+
+rename_dict = (renames.set_index('survey_var')['evioni_var']
+               .dropna()
+               .to_dict())
+untranslated_vars = (renames.loc[renames['evioni_var'].isnull(), 'survey_var']
+                     .tolist())  # variables without cross-definition
+
+orig_data = data.copy()
+# data = data[rename_dict.keys()]  # only keep defined vars
+data.drop(columns=untranslated_vars, inplace=True)
+data.rename(columns=rename_dict, inplace=True)
+
+# Debugging seciton
+_missing_redcap_varnames = [x for x in _current_varnames if x not in data.columns.tolist() ] 
+_variables_without_redcap = [x for x in data.columns.tolist() if x not in _current_varnames]
+assert len(_variables_without_redcap) == 0
+
+## Remaining processing
 # Remove all sessions before ID 22000 - these are junk
 data = data[data['test_sessions_datasetid'] >= 22000]
 

--- a/scripts/import/webcnp/csv2redcap
+++ b/scripts/import/webcnp/csv2redcap
@@ -145,6 +145,8 @@ data = data.drop( ['test_sessions_subid', 'test_sessions_dotest'], axis=1 )
 
 # Bring original "siteid" column back to assign each record to the correct data access group
 data['redcap_data_access_group'] = data['test_sessions_siteid'].map(lambda s: s.lower());
+# In new version, all sites are prefixed with 'NCAN', so we must strip that
+data['redcap_data_access_group'] = data['redcap_data_access_group'].str.replace('ncan', '')
 
 # Make list of dicts for REDCap import
 uploaded = 0

--- a/scripts/import/webcnp/get_results_selenium
+++ b/scripts/import/webcnp/get_results_selenium
@@ -7,24 +7,33 @@
 
 # Setup command line parser
 import argparse
-parser = argparse.ArgumentParser( description="Retrieve CSV spreadsheet from WebCNP database at U Penn" )
-parser.add_argument( "-v", "--verbose", help="Verbose operation", action="store_true" )
+from sibispy import config_file_parser as cfg_parser
+from typing import List
 
-period = parser.add_mutually_exclusive_group()
-period.add_argument( "--from-date", help="Retrieve only records from the specific date onwards. Give date as 'YYYY-MM-DD'.", action="store" )
-period.add_argument( "--on-date", help="Retrieve only records from the specific date. Give date as 'YYYY-MM-DD'.", action="store")
-period.add_argument( "--last-month", help="Retrieve only records of the last month.", action="store_true" )
-period.add_argument( "--last-3-months", help="Retrieve only records of the last 3 months.", action="store_true" )
-period.add_argument( "--last-year", help="Retrieve only records of the last year.", action="store_true" )
+def parse_args(input_args: List[str] = None):
+    parser = argparse.ArgumentParser( description="Retrieve CSV spreadsheet from WebCNP database at U Penn" )
+    parser.add_argument( "-v", "--verbose", help="Verbose operation", action="store_true" )
 
-parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
-parser.add_argument("-t","--time-log-dir",
-                    help="If set then time logs are written to that directory",
-                    action="store",
-                    default=None)
-parser.add_argument( "out_dir", help="Directory for output files" )
+    period = parser.add_mutually_exclusive_group()
+    period.add_argument( "--from-date", help="Retrieve only records from the specific date onwards. Give date as 'YYYY-MM-DD'.", action="store" )
+    period.add_argument( "--on-date", help="Retrieve only records from the specific date. Give date as 'YYYY-MM-DD'.", action="store")
+    period.add_argument( "--last-month", help="Retrieve only records of the last month.", action="store_true" )
+    period.add_argument( "--last-3-months", help="Retrieve only records of the last 3 months.", action="store_true" )
+    period.add_argument( "--last-year", help="Retrieve only records of the last year.", action="store_true" )
 
-args = parser.parse_args()
+    parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
+    parser.add_argument("-t","--time-log-dir",
+                        help="If set then time logs are written to that directory",
+                        action="store",
+                        default=None)
+    parser.add_argument( "out_dir", help="Directory for output files" )
+
+    args = parser.parse_args()
+    return args
+
+
+args = parse_args()
+
 # Import everything we need from Selenium
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -57,63 +66,71 @@ if not sibis_session.configure() :
     slog.info("get_results_selenium","Error: session configure file was not found")
     sys.exit()
 
-browser = sibis_session.connect_server('browser_penncnp', True)
-if not browser: 
-    slog.info("get_results_selenium","Error: could not connect to penncnp")
-    sys.exit()
+config_parser, err = sibis_session.get_config_sys_parser()
+cnp_config = config_parser.get_category('session').get('penncnp')
 
-# Wait for export form and fill appropriately
-wait = sibis_session.initialize_penncnp_wait()
-export = sibis_session.get_penncnp_export_report(wait)
-if not export:
-    sys.exit(1)
 
-browser.find_element_by_name("incomplete").click()
+with sibis_session.connect_server('browser_penncnp', True) as browser:
+    if not browser: 
+        slog.info("get_results_selenium","Error: could not connect to penncnp")
+        sys.exit()
 
-# If "from-date" or "on-date" was given, select date and comparison operator
-# If one of the default options was passed, select _that_
-# Otherwise, the "ALL" default is used
-if args.from_date:
-    browser.find_element_by_name("date_of_test").send_keys(">>")    # selects ">="
-    browser.find_element_by_name("date_of_test_date").send_keys(args.from_date)
-elif args.on_date:
-    browser.find_element_by_name("date_of_test").send_keys("=")     # selects "="
-    browser.find_element_by_name("date_of_test_date").send_keys(args.on_date)
-elif args.last_month:
-    browser.find_element_by_name("date_of_test").send_keys("ll")    # selects "Last Month"
-elif args.last_3_months:
-    browser.find_element_by_name("date_of_test").send_keys("lll")   # selects "Last 3 Months"
-elif args.last_year:
-    browser.find_element_by_name("date_of_test").send_keys("llll")  # selects "Last Year"
+    # BATTERY_NAME = '42:  EVIONI2_battery'
+    # BATTERY_NAME = "302:  NCANDA"
+    BATTERY_NAME = cnp_config['battery']
 
-# 2018-09-04: Need to select right report 
-# After redesign, we need to use the autocomplete input, which doesn't have a unique ID
-# XPATH: /html/body/center/table[2]/tbody/tr[2]/td/center/center/form/table[2]/tbody/tr[7]/td/ul/li[1]/input[2]
-# Better: //select[@id="report_name"]/following-sibling::input[1]
-report_autocomplete_input = browser.find_element_by_xpath('//select[@id="report_name"]/following-sibling::input[1]')
-report_autocomplete_input.click()  # erases the current value, sometimes
-report_autocomplete_input.send_keys(Keys.BACKSPACE * 50)  # ...but just to be sure
-report_autocomplete_input.send_keys('42:  EVIONI2_battery')
-sleep(2)  # The input field can take a bit to load the autocomplete value that we're down-arrowing to
-report_autocomplete_input.send_keys(Keys.DOWN)
-report_autocomplete_input.send_keys(Keys.RETURN)
-# This will set the browser.find_element_by_name('report_name') to the correct value.
+    # Wait for export form and fill appropriately
+    wait = sibis_session.initialize_penncnp_wait()
+    export = sibis_session.get_penncnp_export_report(wait)
+    if not export:
+        sys.exit(1)
 
-# Click "export" button now.
-export.click()
+    browser.find_element_by_name("incomplete").click()
 
-# Wait for "Download" link, start download
-download = wait.until(EC.element_to_be_clickable((By.NAME,'download_excel')))
-download.click()
-logout = wait.until(EC.element_to_be_clickable((By.LINK_TEXT,'Logout')))
+    # If "from-date" or "on-date" was given, select date and comparison operator
+    # If one of the default options was passed, select _that_
+    # Otherwise, the "ALL" default is used
+    if args.from_date:
+        browser.find_element_by_name("date_of_test").send_keys(">>")    # selects ">="
+        browser.find_element_by_name("date_of_test_date").send_keys(args.from_date)
+    elif args.on_date:
+        browser.find_element_by_name("date_of_test").send_keys("=")     # selects "="
+        browser.find_element_by_name("date_of_test_date").send_keys(args.on_date)
+    elif args.last_month:
+        browser.find_element_by_name("date_of_test").send_keys("ll")    # selects "Last Month"
+    elif args.last_3_months:
+        browser.find_element_by_name("date_of_test").send_keys("lll")   # selects "Last 3 Months"
+    elif args.last_year:
+        browser.find_element_by_name("date_of_test").send_keys("llll")  # selects "Last Year"
 
-# At this point, the file should download and save automatically. We need to wait for that to complete.
-while glob.glob( '*.csv.part' ):
-    pass
+    # 2018-09-04: Need to select right report 
+    # After redesign, we need to use the autocomplete input, which doesn't have a unique ID
+    # XPATH: /html/body/center/table[2]/tbody/tr[2]/td/center/center/form/table[2]/tbody/tr[7]/td/ul/li[1]/input[2]
+    # Better: //select[@id="report_name"]/following-sibling::input[1]
+    report_autocomplete_input = browser.find_element_by_xpath('//select[@id="report_name"]/following-sibling::input[1]')
+    report_autocomplete_input.click()  # erases the current value, sometimes
+    report_autocomplete_input.send_keys(Keys.BACKSPACE * 50)  # ...but just to be sure
+    report_autocomplete_input.send_keys(BATTERY_NAME)
+    sleep(2)  # The input field can take a bit to load the autocomplete value that we're down-arrowing to
+    report_autocomplete_input.send_keys(Keys.DOWN)
+    report_autocomplete_input.send_keys(Keys.RETURN)
+    # This will set the browser.find_element_by_name('report_name') to the correct value.
 
-# To clean up, log out of CNP system and quit browser
-logout.click()
-sibis_session.disconnect_penncnp()
+    # Click "export" button now.
+    export.click()
+
+    # Wait for "Download" link, start download
+    download = wait.until(EC.element_to_be_clickable((By.NAME,'download_excel')))
+    download.click()
+    logout = wait.until(EC.element_to_be_clickable((By.LINK_TEXT,'Logout')))
+
+    # At this point, the file should download and save automatically. We need to wait for that to complete.
+    while glob.glob( '*.csv.part' ):
+        pass
+
+    # To clean up, log out of CNP system and quit browser
+    logout.click()
+# sibis_session.disconnect_penncnp()
 
 # Change back to original working directory
 os.chdir( original_wd )


### PR DESCRIPTION
Main new things:

0. Look up battery name from ncanda-operations config (separate PR)
1. Using a variable name lookup, since the latest change also changes variable names
2. Using context manager from a sibispy update (separate PR)