### PR TITLE
268 purge outdated imports

### DIFF
--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -111,7 +111,6 @@ def retrieve_date_data(api, fields, events=None, records=None):
                               })
     return data
 
-
 def mark_lagging_dates(data, comparison_var, days_duration):
     comparisons = data.loc[:, [comparison_var]]
     df = data.drop(columns=[comparison_var]).copy()

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -24,9 +24,6 @@ from six import string_types
 from sibispy import sibislogger as slog
 import json
 
-# Changeable UID template for logging each dataframe by row
-UID_TEMPLATE = "Wrong date - {study_id}/{redcap_event_name}/{form}"
-
 def parse_args(arg_input=None):
     parser = argparse.ArgumentParser(
             description="Find and purge all Entry forms that precede the visit date",)
@@ -180,6 +177,8 @@ def main(api, args):
 
     return marks[marks['purgable']]
 
+# Changeable UID template for logging each dataframe by row
+UID_TEMPLATE = "WrongDate-{study_id}/{redcap_event_name}/{form}"
 
 if __name__ == '__main__':
     args = parse_args(sys.argv)
@@ -204,13 +203,13 @@ if __name__ == '__main__':
     marks = main(redcap_api, args)
 
     # Log dataframe by row here, one for exceeds, and another for precedes
-    log_dataframe_by_row(marks[marks['exceeds']], uid_template=UID_TEMPLATE, message="Entry form exceeds visit date.",
-        description="Listed is an entry form that exceeds the visit date by 120 days.")
-    log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, message="Entry forms precedes visit date.",
-        description="Listed is an entry form that precedes the visit date.")
+    log_dataframe_by_row(marks[marks['exceeds']], uid_template=UID_TEMPLATE, message=f"Form exceeds visit date by {args.max_days_after_visit} days",
+        resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
+    log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, message=f"Form precedes visit date by {args.max_days_after_visit} days",
+        resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
 
     if args.output:
         marks.to_csv(args.output)
     else:
-        with pd.option_context('display.max_rows', 1):
+        with pd.option_context('display.max_rows', None):
             print(marks)

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -125,12 +125,14 @@ def mark_lagging_dates(data, comparison_var, days_duration):
     return data_comp
 
 def log_dataframe_by_row(errors_df: pd.DataFrame,
-                         uid_template: str = "{study_id}/{redcap_event_name}/{form}",
+                         uid_template: str = "{id}/{redcap_event_name}/{form}",
                          **kwargs):
     """
     Convert each row of the DataFrame into a Sibislogger issue.
     General idea: Each column in errors_df is reported, each additional keyword
     argument is a template that gets populated with data from the columns.
+
+    Note: imported from 'error_handling.py' within 'hivalc-data-integration'
     """
 
     def log_row(row: pd.Series, **kwargs):

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -82,7 +82,7 @@ def get_events(api, events=None, arm=None):
     event_names = []        
     for event in api.events:
         if (event["unique_event_name"] in events):
-            if (arm == -1 or event["arm_num"] == arm):
+            if (event["arm_num"] == arm):
                 event_names.append(event["unique_event_name"])
     return event_names
 
@@ -118,6 +118,7 @@ def mark_lagging_dates(data, comparison_var, days_duration):
     data_long = df.stack().to_frame('date').reset_index(-1)
     data_comp = data_long.join(comparisons)
     # Maybe extract previous code into data prep?
+    print(data_comp)
     data_comp['precedes'] = data_comp['date'] < data_comp['visit_date']
     data_comp['exceeds']  = data_comp['date'] > data_comp['visit_date'] + pd.Timedelta(days=days_duration)
     data_comp['purgable'] = data_comp['precedes'] | data_comp['exceeds']
@@ -149,13 +150,12 @@ def log_dataframe_by_row(errors_df: pd.DataFrame,
 def main(api, args):
     events = []
     arm = args.arm
-
-    # Handling no events arg, so all events are chosen and arm doesn't matter
+    print(arm)
+    # Handling no events arg, so all events are chosen
     # Note: should it always pull from one arm when all forms or all arms?
     if (args.events == None):
         for event in api.events:
             events.append(event["unique_event_name"])
-        arm = -1
     else:
         events = args.events
 
@@ -168,7 +168,6 @@ def main(api, args):
 
     meta = api.export_metadata(format='df')
     lookup = get_form_lookup_for_vars(datevars, meta)
-
     data = retrieve_date_data(api, fields=datevars, events=events, 
                               records=args.subjects)
 

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -203,9 +203,11 @@ if __name__ == '__main__':
     marks = main(redcap_api, args)
 
     # Log dataframe by row here, one for exceeds, and another for precedes
-    log_dataframe_by_row(marks[marks['exceeds']], uid_template=UID_TEMPLATE, message=f"Form exceeds visit date by {args.max_days_after_visit} days",
+    log_dataframe_by_row(marks[marks['exceeds']], uid_template=UID_TEMPLATE, 
+        message=f"Form exceeds visit date by {args.max_days_after_visit} days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
-    log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, message=f"Form precedes visit date by {args.max_days_after_visit} days",
+    log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, 
+        message=f"Form precedes visit date by {args.max_days_after_visit} days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
 
     if args.output:

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -169,8 +169,8 @@ def main(api, args):
     marks['visit_date'] = marks['visit_date'].astype(str)
 
     # Log each dataframe by row
-    log_dataframe_by_row(marks, message="All entry forms that precede the visit date",
-        description="Listed are all entry forms that precede the visit date")
+    log_dataframe_by_row(marks[marks['purgable']], message="All entry forms that precede the visit date",
+        description="Listed are all entry forms that precede the visit date.")
 
     return marks[marks['purgable']]
 

--- a/scripts/redcap/purge_outdated.py
+++ b/scripts/redcap/purge_outdated.py
@@ -118,7 +118,6 @@ def mark_lagging_dates(data, comparison_var, days_duration):
     data_long = df.stack().to_frame('date').reset_index(-1)
     data_comp = data_long.join(comparisons)
     # Maybe extract previous code into data prep?
-    print(data_comp)
     data_comp['precedes'] = data_comp['date'] < data_comp['visit_date']
     data_comp['exceeds']  = data_comp['date'] > data_comp['visit_date'] + pd.Timedelta(days=days_duration)
     data_comp['purgable'] = data_comp['precedes'] | data_comp['exceeds']
@@ -150,7 +149,7 @@ def log_dataframe_by_row(errors_df: pd.DataFrame,
 def main(api, args):
     events = []
     arm = args.arm
-    print(arm)
+
     # Handling no events arg, so all events are chosen
     # Note: should it always pull from one arm when all forms or all arms?
     if (args.events == None):
@@ -170,7 +169,6 @@ def main(api, args):
     lookup = get_form_lookup_for_vars(datevars, meta)
     data = retrieve_date_data(api, fields=datevars, events=events, 
                               records=args.subjects)
-
     marks = mark_lagging_dates(data, comparison_date_var, 
                                days_duration=args.max_days_after_visit)
 

--- a/scripts/redcap/wrong_date_associations.py
+++ b/scripts/redcap/wrong_date_associations.py
@@ -207,7 +207,7 @@ if __name__ == '__main__':
         message=f"Form exceeds visit date by {args.max_days_after_visit} days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
     log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, 
-        message=f"Form precedes visit date by a non-zero number of days: {args.max_days_after_visit} days",
+        message=f"Form precedes visit date by a non-zero number of days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
 
     if args.output:

--- a/scripts/redcap/wrong_date_associations.py
+++ b/scripts/redcap/wrong_date_associations.py
@@ -207,7 +207,7 @@ if __name__ == '__main__':
         message=f"Form exceeds visit date by {args.max_days_after_visit} days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
     log_dataframe_by_row(marks[marks['precedes']], uid_template=UID_TEMPLATE, 
-        message=f"Form precedes visit date by {args.max_days_after_visit} days",
+        message=f"Form precedes visit date by a non-zero number of days: {args.max_days_after_visit} days",
         resolution="Contact site to determine if the date is incorrect and should be changed, if the form should be emptied, or if an exception should be set.")
 
     if args.output:


### PR DESCRIPTION
**Fixes made**:

- Changed uid_template to better reflect the error. I specifically added 'Wrong date' at the beginning, and kept the default template for log_dataframe_by_row
- Logged each individual dataframe by both those that exceeded the visit date by 120 days, as well as those that preceded the visit day. Moved those calls also to the main function, once marks is returned from the main() function.
- Fixed the error with no param run: basically, events had no default value, so I had to just append all event['unique_event_name'] object from api.events into the events array. Using that made it all easier, and honestly, I wouldn't even need to call 'get_events()' to the function if no events args are shown.

**Things for the Future**:

- When there are no params, do we consider all events AND all arms?
- Still need to sanity check, as well as check on ncanda-storage (might need a refresher)
- Just making output is expected, especially when considering other arms
- Fix error with a specific arm -- seems to not pick up the 'visit_date' column only for arms = 3 and 6? Not sure.