### PR TITLE
Drop Stroop Z-scores from the produced CSV file

### DIFF
--- a/scripts/import/laptops/stroop2csv
+++ b/scripts/import/laptops/stroop2csv
@@ -17,6 +17,7 @@ import math
 import argparse
 import hashlib
 import numpy as np
+import pandas as pd
 from pathlib import Path
 
 from convert_util import post_issue
@@ -276,9 +277,6 @@ zs[7]=0.5*(z[2]+z[3])
 
 if not os.path.exists(args.outdir):
     os.makedirs(args.outdir)
-output_file = open( output_filename, 'w' )
-
-wr = csv.writer( output_file, quoting=csv.QUOTE_ALL)
 
 if args.mr_session:
     record_id_variable = "study_id"
@@ -301,6 +299,7 @@ result=[record_id,1,mean[8],std[8],median[8],z[8],error[8],
         miss[0],miss[1],miss[2],miss[3],miss[4],miss[5], miss[6],miss[7],Diff[0],
         Diff[1],Diff[2],Diff[3],Diff[4],Diff[5],Diff[6],Diff[7],zs[0],zs[1],zs[2],zs[3],zs[4],zs[5],zs[6],zs[7]]
 
+
 title.append( 'stroop_timeofday' )
 result.append( time_of_day )
 
@@ -319,9 +318,30 @@ if args.event:
     title.append( 'redcap_event_name' )
     result.append( args.event )
 
-wr.writerow(title)
-wr.writerow(result)
-
-output_file.close()
+result_dict = dict(zip(title, result))
+# Drop useless z-scores which are apparently non-representative
+useless_cols = [
+    "stroop_conm_rr_z",
+    "stroop_conm_rs_z",
+    "stroop_connm_rr_z",
+    "stroop_connm_rs_z",
+    "stroop_incm_rr_z",
+    "stroop_incm_rs_z",
+    "stroop_incnm_rr_z",
+    "stroop_incnm_rs_z",
+    "stroop_stroopm_rr_z",
+    "stroop_stroopnm_rr_z",
+    "stroop_stroopm_rs_z",
+    "stroop_stroopnm_rs_z",
+    "stroop_stroopm_z",
+    "stroop_stroopnm_z",
+    "stroop_rr_z",
+    "stroop_rs_z"
+]
+result_dict = {key: [val] for key, val in result_dict.items()
+               if key not in useless_cols}
+result_df = pd.DataFrame(result_dict)
+result_df.to_csv(output_filename, index=False, na_rep='',
+                 quoting=csv.QUOTE_ALL)
 
 print(output_filename)


### PR DESCRIPTION
**Note;** I have misgivings that this is the way forward. Following this with deleting Z-score variables from the Entry project means that previously generated Stroop files will fail to upload with `csv2redcap`. Any path to normalizing that - e.g. regenerating a lot of Stroop files - risks overwriting changes to existing data (but perhaps there shouldn't be any, given the nature of the measurements we're dealing with here?) and, at the very least, mixing up completion statuses.

I'd prefer to just hide the Z-scores in Data Entry and not generate them going forward (i.e., keep them empty instead of dropping them).

Either way: Tested via `/fs/ncanda-share/beta/simon/stroop_export/scripts/import/laptops/stroop2csv /fs/storage/laptops/ncanda/sri5/B-80451-F-1-20140214/NCANDAStroopMtS_3cycles_7m53stask_100SD-2804-5121.txt /tmp/` - same output minus Z-scores as the original script.