### PR TITLE
No longer complain about unparsable DICOM if scan is unusable

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1130,7 +1130,7 @@ for (eid, project, subject, insert_date,
                     # Remove qc_file as session has to be checked again 
                     remove_file(session_label,qc_file_tmp)
 
-                    if len(error_msg) :
+                    if len(error_msg) and quality != "unusable":
                         nifti_export_ok = False
                         htmln.append(''.join([session_html_link,
                                               session_dir_link,


### PR DESCRIPTION
Tested with `./check_new_sessions -e NCANDA_E10762 -v`.