### PR TITLE
Change log file for schedule_cluster_job

### DIFF
--- a/scripts/redcap/export_mr_sessions_pipeline.py
+++ b/scripts/redcap/export_mr_sessions_pipeline.py
@@ -513,7 +513,10 @@ def export_and_queue(red2cas, redcap_visit_id, xnat, session_data, redcap_key, p
         just_pipeline_script=os.path.basename(run_pipeline_script)
         qsub_exe = 'cd %s; %s %s' % ( pipeline_root_dir,run_pipeline_script,pipeline_workdir_rel)
         # Changed title so it is informative when displayed in short form through qsub
-        red2cas.schedule_cluster_job(qsub_exe,'N%s%s-%s-Nightly' % (subject_code[7:],visit_code[0] + visit_code[9:],just_pipeline_script),submit_log='/tmp/ncanda_test_nightly.txt', verbose = verbose)
+
+        job_title = subject_code[7:] + visit_code[0] + visit_code[9:] + '-' + just_pipeline_script
+        log_file = '/fs/ncanda-share/log/export_mr_sessions_pipeline' + job_title + '.txt'
+        red2cas.schedule_cluster_job(qsub_exe,'N%s-Nightly' % (job_title),submit_log=log_file, verbose = verbose)
             
     # It is very important to clear the PyXNAT cache, lest we run out of disk space and shut down all databases in the process
     try:


### PR DESCRIPTION
This diff does the following:

1. Change the logging location for schedule_cluster_job in export_mr_sessions_pipeline.py to `/fs/ncanda-share/log/export_mr_sessions_pipeline`
2. The log file name will be the job title name