### PR TITLE
Add project names to scans_to_review.csv conversion

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -675,11 +675,14 @@ def convert_qc_csv(filename: str, new_filename: str, verbose: bool = False):
             )
         return
 
-    # TODO the project_name column is required, but unused.
-    # For now, just omit it.
-    project_name = ''
+    project_name_pattern = re.compile('([a-z]+)_incoming')
     new_rows = []
     for _index, row in df.iterrows():
+        match = project_name_pattern.search(row['nifti_folder'])
+        if match:
+            project_name = match.group(1)
+        else:
+            project_name = 'unknown'
         new_rows.append(
             [
                 project_name,


### PR DESCRIPTION
@jimklo This should resolve the issue of missing project names in the converted `scans_to_review_v2.csv`.

This code does make the assumption that the project can always be extracted from the file path by matching `[a-z]+_incoming`, which is true for all the projects I'm aware, but may not be true in general.