### PR TITLE
Feature/remove missing scans whitespace

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -327,7 +327,7 @@ def incomplete_scan_check(experiment,manufacturer, session_label, eid, scan_type
         slog.info(session_label,
                   err_msg,
                   manufacturer=manufacturer,
-                  missing_scans=', '.join(missing_scans),
+                  missing_scans=','.join(missing_scans),
                   eid=eid,
                   site_forward=dag,
                   site_resolution="If the scans exist, please upload them to "


### PR DESCRIPTION
Makes it easier to paste the missing scans into special_cases, which requires no spaces between scans