### PR TITLE
Bug/batch resolving locking using de form names

### DIFF
--- a/scripts/reporting/batch_resolve_locking_issues.py
+++ b/scripts/reporting/batch_resolve_locking_issues.py
@@ -45,7 +45,7 @@ def run_batch(label, issue_numbers, metadata, force, verbose):
         automatic_issues = ["redcap_update_summary_scores"]
         if label not in automatic_issues and not force:
             if not utils.prompt_y_n(
-                f"Unlock/recalculate/lock issue? ({scraped_issue.issue.html_url})"
+                    f"Unlock/recalculate/lock issue? IMPORTANT: Make sure there are not other locking issues involving the subject id you are about to recalculate before continuing. Otherwise, invalid data may propagate.\n({scraped_issue.issue.html_url})"
             ):
                 continue
 

--- a/scripts/reporting/issues.py
+++ b/scripts/reporting/issues.py
@@ -133,6 +133,8 @@ class UpdateVisitDataIssue(Issue):
             first_field = self.body["requestError"].split('","')[1]
             field_row = metadata[metadata["field_name"] == first_field]
             self.form = field_row["form_name"].item()
+            if "limesurvey_ssaga" in self.form:
+                self.form = "_".join(self.body['redcap_variable'].split('_')[:-1])
             for study_id in study_ids:
                 command = commands.UpdateVisitDataCommand(
                     self.verbose, study_id, self.form


### PR DESCRIPTION
To resolve this issue: https://github.com/sibis-platform/ncanda-operations/issues/10563
Basically, batch_resolve_locking_issues is extracting the name of the form in Data Entry which is locked. Usually this is good enough recalculate the form, but since limesurvey stitches together multiple forms from Imports, and update_visit_data takes in the name of the form in imports, I had to add some special logic to extract the specific limesurvey form from the issue body.