### PR TITLE
bug/batch_resolve_locking_lssaga_forms

### DIFF
--- a/scripts/reporting/issues.py
+++ b/scripts/reporting/issues.py
@@ -1,6 +1,6 @@
 import batch_script_utils as utils
 import commands
-
+import re
 
 class Issue(object):
     """
@@ -133,11 +133,13 @@ class UpdateVisitDataIssue(Issue):
             first_field = self.body["requestError"].split('","')[1]
             field_row = metadata[metadata["field_name"] == first_field]
             self.form = field_row["form_name"].item()
+            imports_form = self.form
             if "limesurvey_ssaga" in self.form:
-                self.form = "_".join(self.body['redcap_variable'].split('_')[:-1])
+                lssaga_regex = "(lssaga[1234]_youth|lssaga[1234]_parent)"
+                imports_form = re.match(lssaga_regex, self.body['redcap_variable'])[0]
             for study_id in study_ids:
                 command = commands.UpdateVisitDataCommand(
-                    self.verbose, study_id, self.form
+                    self.verbose, study_id, imports_form
                 )
                 self.commands.append(command)
         elif "form_name" in self.body:

--- a/scripts/reporting/issues.py
+++ b/scripts/reporting/issues.py
@@ -136,7 +136,10 @@ class UpdateVisitDataIssue(Issue):
             imports_form = self.form
             if "limesurvey_ssaga" in self.form:
                 lssaga_regex = "(lssaga[1234]_youth|lssaga[1234]_parent)"
-                imports_form = re.match(lssaga_regex, self.body['redcap_variable'])[0]
+                lssaga_matches = re.match(lssaga_regex, self.body['redcap_variable'])
+                if len(lssaga_matches) == 0:
+                    raise ValueError(f"#{self.number}\nNo lssaga form in redcap_variable")
+                imports_form = lssaga_matches[0]
             for study_id in study_ids:
                 command = commands.UpdateVisitDataCommand(
                     self.verbose, study_id, imports_form

--- a/scripts/reporting/issues.py
+++ b/scripts/reporting/issues.py
@@ -137,7 +137,7 @@ class UpdateVisitDataIssue(Issue):
             if "limesurvey_ssaga" in self.form:
                 lssaga_regex = "(lssaga[1234]_youth|lssaga[1234]_parent)"
                 lssaga_matches = re.match(lssaga_regex, self.body['redcap_variable'])
-                if len(lssaga_matches) == 0:
+                if not lssaga_matches:
                     raise ValueError(f"#{self.number}\nNo lssaga form in redcap_variable")
                 imports_form = lssaga_matches[0]
             for study_id in study_ids:


### PR DESCRIPTION
In the previous attempt at a fix for this bug, #458, I changed the form stored in the Issue class. This was not the right thing to do, since this form is passed to the unlocking script and thus should be the Data Entry form, not the imports form. Now the imports form is only passed to update_visit_data, and the data entry form is passed to the unlocking script, as it should be.
Should resolve https://github.com/sibis-platform/ncanda-operations/issues/10564 and related issues.