### PR TITLE
Added check for experiment_site_id in check_phantom_scans issues

### DIFF
--- a/scripts/reporting/issues.py
+++ b/scripts/reporting/issues.py
@@ -269,6 +269,10 @@ class CheckPhantomScansIssue(Issue):
             experiment_id = self.body["experiment_id"]
             command = commands.CheckPhantomScansCommand(self.verbose, experiment_id)
             self.commands.append(command)
+        elif "experiment_site_id" in self.body:
+            experiment_site_id = self.body["experiment_site_id"]
+            command = commands.CheckPhantomScansCommand(self.verbose, experiment_site_id)
+            self.commands.append(command)
         else:
             raise ValueError(f"#{self.number}\nexperiment_id not in body")
 


### PR DESCRIPTION
Check_phantom_scans issue bodies are inconsistent: some have an experiment_id field, others an experiment_site_id field. Now the issue scraper catches both.