### PR TITLE
Readded short circuit

### DIFF
--- a/scripts/import/webcnp/csv2redcap
+++ b/scripts/import/webcnp/csv2redcap
@@ -185,7 +185,8 @@ if not args.import_all:
 else:
     # ignore data sets that are set to complete (status = 2)
     not_in_existing_or_not_complete = data["record_id"].map(
-        lambda x: x not in existing or records_in_redcap.loc[
+        lambda x: x not in existing
+        or records_in_redcap.loc[
             records_in_redcap["record_id"] == x,
             "test_sessions_complete",
         ].values[0]
@@ -258,7 +259,7 @@ data["redcap_data_access_group"] = data["redcap_data_access_group"].str.replace(
 uploaded = 0
 for [key, row] in data.iterrows():
     record = dict(row.dropna())
-       
+
     # Upload new data to REDCap
     import_response = session.redcap_import_record_to_api(
         [record], None, "csv2redcap-import"

--- a/scripts/import/webcnp/csv2redcap
+++ b/scripts/import/webcnp/csv2redcap
@@ -184,7 +184,7 @@ if not args.import_all:
     data = data[not_in_existing]
 else:
     # ignore data sets that are set to complete (status = 2)
-    not_in_exisitng_or_not_complete = data["record_id"].map(
+    not_in_existing_or_not_complete = data["record_id"].map(
         lambda x: x not in existing or records_in_redcap.loc[
             records_in_redcap["record_id"] == x,
             "test_sessions_complete",

--- a/scripts/import/webcnp/csv2redcap
+++ b/scripts/import/webcnp/csv2redcap
@@ -184,14 +184,14 @@ if not args.import_all:
     data = data[not_in_existing]
 else:
     # ignore data sets that are set to complete (status = 2)
-    not_complete = data["record_id"].map(
-        lambda x: records_in_redcap.loc[
+    not_in_exisitng_or_not_complete = data["record_id"].map(
+        lambda x: x not in existing or records_in_redcap.loc[
             records_in_redcap["record_id"] == x,
             "test_sessions_complete",
         ].values[0]
         != 2
     )
-    data = data[not_in_existing | not_complete]
+    data = data[not_in_existing_or_not_complete]
 
 # Anything left?
 if not len(data) and args.verbose:


### PR DESCRIPTION
The previous code did not try to check the completion status of records which did not exist in redcap yet. It did so by short-circuiting the logical AND: any forms which were not present in redcap made the first value True, so the completion status was never checked (and thus the out-of-bound error was never triggered). The change in #478 messed this up, since it split up the existence and completion checking. I am now doing them together again.