### PR TITLE
Passing redcap_event_name directly to redcap address function

### DIFF
--- a/scripts/import/laptops/update_visit_data
+++ b/scripts/import/laptops/update_visit_data
@@ -812,11 +812,10 @@ for form_prefix, form_name in forms.items():
         disable=not args.progress_bar,
     ):
         study_id = key[0]
-        event = key[1]
+        redcap_event_name = key[1]
         project_id = redcap_project.export_project_info()['project_id']
-        visit = re.match('(baseline_visit)|(\d*y_visit)|(\d*month_followup)',event).group()
-        arm_num = int(re.search('arm_(\d*)', event).group(1))
-        redcap_url = session.get_formattable_redcap_form_address(project_id, visit, arm_num, study_id, form_name)
+
+        redcap_url = session.get_formattable_redcap_form_address(project_id, redcap_event_name, study_id, form_name)
 
         if args.verbose:
             print("Processing", key)

--- a/scripts/redcap/update_bulk_forms
+++ b/scripts/redcap/update_bulk_forms
@@ -383,9 +383,8 @@ for form in forms_list:
                                 old_form_status[err_field][error_index_list].values
                             )
                             project_id = rc_entry.export_project_info()['project_id']
-                            visit = re.match('(baseline_visit)|(\d*y_visit)|(\d*month_followup)',event).group()
-                            arm_num = int(re.search('arm_(\d*)', event).group(1))
-                            url = session.get_formattable_redcap_form_address(project_id, visit, arm_num, err_subject_id, form)
+                            
+                            url = session.get_formattable_redcap_form_address(project_id, event, err_subject_id, form)
                             slog.info(
                                 error_id,
                                 "Cannot update '"

--- a/scripts/redcap/wrong_date_associations.py
+++ b/scripts/redcap/wrong_date_associations.py
@@ -291,9 +291,7 @@ if __name__ == '__main__':
     # Add urls to marks
     url_info = marks.reset_index()[['study_id', 'form', 'redcap_event_name']]
     url_info['project_id'] = redcap_api.export_project_info()['project_id']
-    url_info['arm_num'] = url_info['redcap_event_name'].str.extract('arm_(\d)')
-    url_info['visit'] = url_info['redcap_event_name'].str.extract('(baseline_visit)|(\d*y_visit)|(\d*month_followup)')[0]
-    marks['url'] = list(map(session.get_formattable_redcap_form_address, url_info['project_id'], url_info['visit'], url_info['arm_num'].astype(int), url_info['study_id'], url_info['form']))
+    marks['url'] = list(map(session.get_formattable_redcap_form_address, url_info['project_id'], url_info['redcap_event_name'], url_info['study_id'], url_info['form']))
 
     # Changeable UID template for logging each dataframe by row
     UID_TEMPLATE = "WrongDate-{study_id}/{redcap_event_name}/{form_date_var}"


### PR DESCRIPTION
The old code assumed the event was from the standard arm. After [this](https://github.com/sibis-platform/sibispy/pull/79) PR, the function accepts arbitrary redcap_event_names. This PR changes the code to use the new util function correctly.