### PR TITLE
Xnat links, Subject IDs, & Session IDs

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -56,6 +56,8 @@ new_sessions = []
 xnat_date_format = "%Y-%m-%d %H:%M:%S"
 dti30b500_check_date = "2017-02-01 00:00:00"
 
+project_list = ["DUKE", "OHSU", "SRI", "UCSD", "UPITT"]
+
 # Get list of all sessions after the chosen date
 # Adding fields such as 'xnat:mrSessionData/scanner/manufacturer' does not work for some reason
 fields_per_session = [
@@ -865,13 +867,6 @@ parser.add_argument(
     "--qc-json",
     help="Write scans to qc to a json file.",
     action="store_true",
-)
-parser.add_argument(
-    "--project_list",
-    help="The list of project names to include in the output file, separated by spaces",
-    default=[],
-    nargs="+",
-    type=str,
 )
 parser.add_argument(
     "-f",
@@ -1691,7 +1686,7 @@ if args.qc_csv_v2:
         args.verbose,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=args.project_list,
+        project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1700,7 +1695,7 @@ if args.qc_csv_v2:
         args.verbose,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=args.project_list,
+        project_list=project_list,
     )
 
 # Or a QC json file
@@ -1713,7 +1708,7 @@ if args.qc_json:
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=args.project_list,
+        project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1723,7 +1718,7 @@ if args.qc_json:
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=args.project_list,
+        project_list=project_list,
     )
 
 

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1671,6 +1671,12 @@ if args.qc_csv or args.qc_csv_v2 or args.qc_json:
     write_scans_to_file(scans_to_qc, "scans_to_review.csv", args.verbose)
     write_scans_to_file(scans_to_question, "scans_to_question.csv", args.verbose)
 
+project_list = (
+    args.project_list.replace("[", "").replace("]", "").replace(" ", "").split(",")
+    if args.project_list
+    else []
+)
+
 if args.qc_csv_v2:
     miqa_file_generation.write_miqa_import_file(
         "scans_to_review.csv",
@@ -1678,6 +1684,7 @@ if args.qc_csv_v2:
         log_dir,
         args.verbose,
         session=sibis_session,
+        project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1685,6 +1692,7 @@ if args.qc_csv_v2:
         log_dir,
         args.verbose,
         session=sibis_session,
+        project_list=project_list,
     )
 
 # Or a QC json file
@@ -1696,6 +1704,7 @@ if args.qc_json:
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
+        project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1704,6 +1713,7 @@ if args.qc_json:
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
+        project_list=project_list,
     )
 
 

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -776,7 +776,7 @@ def write_scans_to_file(
     scans_with_header: List, filename: str, verbose: bool = False
 ) -> bool:
     target_file = os.path.join(log_dir, filename)
-    
+
     if len(scans_with_header) > 1:
         if os.path.exists(target_file + ".lock"):
             target_file = target_file + ".tmp"
@@ -790,10 +790,10 @@ def write_scans_to_file(
         if verbose:
             print(f"Created {target_file} with {len(scans_with_header)} lines")
     elif len(scans_with_header) == 1:
-            with open(target_file, "w") as fi:
-                fi.writelines(scans_with_header)
-                if verbose:
-                    print(f"Created {target_file} with header only")
+        with open(target_file, "w") as fi:
+            fi.writelines(scans_with_header)
+            if verbose:
+                print(f"Created {target_file} with header only")
     else:
         return False
 
@@ -1677,12 +1677,14 @@ if args.qc_csv_v2:
         "scans_to_review_v2.csv",
         log_dir,
         args.verbose,
+        session=sibis_session,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
         "scans_to_question_v2.csv",
         log_dir,
         args.verbose,
+        session=sibis_session,
     )
 
 # Or a QC json file
@@ -1693,6 +1695,7 @@ if args.qc_json:
         log_dir,
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
+        session=sibis_session,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1700,6 +1703,7 @@ if args.qc_json:
         log_dir,
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
+        session=sibis_session,
     )
 
 

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -867,6 +867,12 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument(
+    "--project_list",
+    help="The list of project names to include in the output file",
+    default=[],
+    action="store",
+)
+parser.add_argument(
     "-f",
     "--force-qc-check",
     help="Always perform quality check regardless if it was done before.",

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -868,9 +868,10 @@ parser.add_argument(
 )
 parser.add_argument(
     "--project_list",
-    help="The list of project names to include in the output file",
+    help="The list of project names to include in the output file, separated by spaces",
     default=[],
-    action="store",
+    nargs="+",
+    type=str,
 )
 parser.add_argument(
     "-f",
@@ -1677,11 +1678,6 @@ if args.qc_csv or args.qc_csv_v2 or args.qc_json:
     write_scans_to_file(scans_to_qc, "scans_to_review.csv", args.verbose)
     write_scans_to_file(scans_to_question, "scans_to_question.csv", args.verbose)
 
-project_list = (
-    args.project_list.replace("[", "").replace("]", "").replace(" ", "").split(",")
-    if args.project_list
-    else []
-)
 subject_mapping = {
     eid: subject
     for (eid, project, subject, insert_date, label, last_modified) in new_sessions
@@ -1695,7 +1691,7 @@ if args.qc_csv_v2:
         args.verbose,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=project_list,
+        project_list=args.project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1704,7 +1700,7 @@ if args.qc_csv_v2:
         args.verbose,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=project_list,
+        project_list=args.project_list,
     )
 
 # Or a QC json file
@@ -1717,7 +1713,7 @@ if args.qc_json:
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=project_list,
+        project_list=args.project_list,
     )
     miqa_file_generation.write_miqa_import_file(
         "scans_to_question.csv",
@@ -1727,7 +1723,7 @@ if args.qc_json:
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
         subject_mapping=subject_mapping,
-        project_list=project_list,
+        project_list=args.project_list,
     )
 
 

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1676,6 +1676,10 @@ project_list = (
     if args.project_list
     else []
 )
+subject_mapping = {
+    eid: subject
+    for (eid, project, subject, insert_date, label, last_modified) in new_sessions
+}
 
 if args.qc_csv_v2:
     miqa_file_generation.write_miqa_import_file(
@@ -1684,6 +1688,7 @@ if args.qc_csv_v2:
         log_dir,
         args.verbose,
         session=sibis_session,
+        subject_mapping=subject_mapping,
         project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
@@ -1692,6 +1697,7 @@ if args.qc_csv_v2:
         log_dir,
         args.verbose,
         session=sibis_session,
+        subject_mapping=subject_mapping,
         project_list=project_list,
     )
 
@@ -1704,6 +1710,7 @@ if args.qc_json:
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
+        subject_mapping=subject_mapping,
         project_list=project_list,
     )
     miqa_file_generation.write_miqa_import_file(
@@ -1713,6 +1720,7 @@ if args.qc_json:
         args.verbose,
         format=miqa_file_generation.MIQAFileFormat.JSON,
         session=sibis_session,
+        subject_mapping=subject_mapping,
         project_list=project_list,
     )
 

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -82,8 +82,9 @@ def convert_dataframe_to_new_format(
         for index, frame_location in enumerate(frame_locations):
             frame_number = row["scan_id"] if len(frame_locations) < 2 else index
             experiment = row["xnat_experiment_id"]
+            scan_type = row["scan_type"]
             subject_id = ""
-            session_id = experiment  # TODO populate correctly
+            session_id = "XXXX"  # TODO populate correctly
             scan_link = ""
             if session:
                 scan_link = session.get_xnat_session_address(experiment)
@@ -94,8 +95,8 @@ def convert_dataframe_to_new_format(
                 [
                     project_name,  # project_name
                     experiment,  # experiment_name
-                    f"{experiment}_{row['scan_type']}",  # scan_name
-                    row["scan_type"],  # scan_type
+                    f"{experiment}_{scan_type}",  # scan_name
+                    scan_type,  # scan_type
                     frame_number,  # frame_number
                     str(frame_location),  # file_location
                     row["experiment_note"],  # experiment_notes

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -82,9 +82,8 @@ def convert_dataframe_to_new_format(
         for index, frame_location in enumerate(frame_locations):
             frame_number = row["scan_id"] if len(frame_locations) < 2 else index
             experiment = row["xnat_experiment_id"]
-            # TODO populate these correctly
             subject_id = ""
-            session_id = ""
+            session_id = experiment  # TODO populate correctly
             scan_link = ""
             if session:
                 scan_link = session.get_xnat_session_address(experiment)


### PR DESCRIPTION
This PR addresses the following: 

1. Pass the sibis session to `write_miqa_import_file` so that `session.get_xnat_session_address` can be used to generate the `scan_link` field in the output file
2. Obtain the `project_list` arg for `write_miqa_import_file` from the command line args
3. Pass a mapping of subject IDs to `write_miqa_import_file` to populate the `subject_id` field in the output file
4. Add a placeholder value for the `session_id` field in the output file (Is there some known data that should be used here? Currently we use the experiment id string.)

**I am not able to test the use of the sibis session object. @kipohl  please test before merging and let me know if you run into any issues.**