### PR TITLE
500 typeerror bad operand type for abs str

### DIFF
--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -233,15 +233,15 @@ def encode_session_and_scan( session_and_scan, type_list, match_eid = None ):
         if type in list(session_and_scan.keys()): 
             type_id = session_and_scan[type][0]
             if not match_eid :
-                return "%s/%s" % (type_id,session_and_scan[type][1])
+                return "%s/%s" % (type_id,session_and_scan[type][2])
 
             if type_id == match_eid:
-                return "%s/%s" % (type_id,session_and_scan[type][1])
+                return "%s/%s" % (type_id,session_and_scan[type][2])
 
             id_list = [type_id,match_eid] if type_id < match_eid else [match_eid,type_id]
             exception_id = merge_xnat_sessions.get(id_list[0])
             if exception_id and exception_id  == id_list[1] :
-                return "%s/%s" % (type_id,session_and_scan[type][1])
+                return "%s/%s" % (type_id,session_and_scan[type][2])
 
     return ""
 
@@ -975,3 +975,4 @@ if args.verbose:
         print("Suppressed uploading of %d records to REDCap." % ( len( mr_sessions_redcap ) ))
 
 slog.takeTimer1("script_time","{'records': " + str(len(mr_sessions_redcap)) + ", 'uploads': " +  str(records_uploaded) + "}")
+

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -169,7 +169,7 @@ def get_scans_by_type( red2cas, usable_scans_list, visit_date, redcap_visit_id):
     result = dict()
     for type in ncanda_scan_types:
           # Get list of scans for this type; as we go, compute and sort by number of days between visit date and scan date
-        scans = sorted( [ (eid, xnat_url, scan, red2cas.days_between_dates(visit_date,xnat_sessions_dict[eid][0])) for (scan_type,eid,xnat_url,scan) in usable_scans_list if re.match( '^ncanda-%s-v1$' % type, scan_type ) ], key=lambda x: abs(x[2]) )
+        scans = sorted( [ (eid, xnat_url, scan, red2cas.days_between_dates(visit_date,xnat_sessions_dict[eid][0])) for (scan_type,eid,xnat_url,scan) in usable_scans_list if re.match( '^ncanda-%s-v1$' % type, scan_type ) ], key=lambda x: abs(x[3]) )
 
         # Changed logic here should generally just be one scan across all sessions
         # if (len( scans ) == 1) or (len( scans ) > 1 and scans[0][2] < scans[1][2]): 


### PR DESCRIPTION
I added urls to a tuple, but then didn't change the indexing into that tuple in other parts of the code. Should be fixed now:
```
ncanda@pipeline-back[pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/reporting (master)$ /fs/ncanda-share/beta/griffin/ncanda-data-integration/scripts/redcap/import_mr_sessions --pipeline-root-dir /fs/ncanda-share/cases --run-pipeline-script /fs/ncanda-share/scripts/bin/ncanda_all_pipelines -f --study-id C-70183-F-1 -v
Namespace(event=None, force_update=True, force_update_stroop=False, max_days_after_visit=120, missing_only=False, no_stroop=False, no_upload=False, pipeline_root_dir='/fs/ncanda-share/cases', post_to_github=False, run_pipeline_script='/fs/ncanda-share/scripts/bin/ncanda_all_pipelines', site=None, study_id='C-70183-F-1', time_log_dir=None, verbose=True)
Checking 10 REDCap records.
1 Processing ('C-70183-F-1', 'baseline_visit_arm_1')
Checking C-70183-F-1 for baseline_visit_arm_1 with visit date 2014-06-08 to 2014-10-06
XNAT Session Data: [('NCANDA_E02125', '<duke_incoming>', '2014-06-20')]
C-70183-F-1 / NCANDA_S00888 / baseline_visit_arm_1 to /fs/ncanda-share/cases/NCANDA_S00888/standard/baseline
2 Processing ('C-70183-F-1', '1y_visit_arm_1')
Checking C-70183-F-1 for 1y_visit_arm_1 with visit date 2015-06-20 to 2015-10-18
XNAT Session Data: [('NCANDA_E04251', '<duke_incoming>', '2015-06-22')]
check_for_stroop: ['NCANDA_E04251']
check_for_stroop: no stroop
C-70183-F-1 / NCANDA_S00888 / 1y_visit_arm_1 to /fs/ncanda-share/cases/NCANDA_S00888/standard/followup_1y

```
...etc