### PR TITLE
Make no assumptions about the content of the scan note free text

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1507,9 +1507,9 @@ for (
             scan_note = experiment.scans[scan].get("note") or ""
             scan_note = sanitize_string_for_csv(scan_note)
             quality_translation = defaultdict(lambda: "")
-            quality_translation["usable"] = "U"
-            quality_translation["usable-extra"] = "UE"
-            quality_translation["questionable"] = "Q?"
+            quality_translation["usable"] = "1"
+            quality_translation["usable-extra"] = "2"
+            quality_translation["questionable"] = "0"
             decision = quality_translation[quality]
             row = (
                 f'{eid},{session_dir},{scan},{scan_type},"{exp_note}",'

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1507,9 +1507,9 @@ for (
             scan_note = experiment.scans[scan].get("note") or ""
             scan_note = sanitize_string_for_csv(scan_note)
             quality_translation = defaultdict(lambda: "")
-            quality_translation["usable"] = "1"
-            quality_translation["usable-extra"] = "2"
-            quality_translation["questionable"] = "0"
+            quality_translation["usable"] = "U"
+            quality_translation["usable-extra"] = "UE"
+            quality_translation["questionable"] = "Q?"
             decision = quality_translation[quality]
             row = (
                 f'{eid},{session_dir},{scan},{scan_type},"{exp_note}",'

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -93,7 +93,7 @@ def convert_dataframe_to_new_format(
             decision = (
                 MIQADecisionCodes[row["decision"]]
                 if row["decision"] in MIQADecisionCodes
-                else "Q?"
+                else ""
             )
 
             new_rows.append(


### PR DESCRIPTION
Instead of trying to parse the user and creation time of a decision from the unformatted text of the note column, this PR makes no assumptions about that content and copies it to the import file as-is. MIQA will then fill in its own creation time at the time of import and the creator can be null. We just have to hope that the decision-maker signed their initials in the free text in order to identify who made the decision.

Here is a screenshot of one such decision after being imported:
![image](https://user-images.githubusercontent.com/44912689/175310616-8014212f-ed69-402f-9bbc-dbf63d25d1cf.png)
