### PR TITLE
Add multiple decision schema

### DIFF
--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -1,3 +1,4 @@
+from dateutil.parser import parse
 import json
 import os
 import re
@@ -63,12 +64,11 @@ def convert_json_to_check_new_sessions_df(
                         data["scan_note"] = scan["last_decision"]["note"]
 
                 if "decisions" in scan and scan["decisions"] is not None and len(scan["decisions"]) > 0:
-                    # TODO: what is the desired behavior here?
-                    # Can we record multiple decisions to this data structure?
-                    data["decision"] = MIQA2CNSDecisionCodes[scan["decisions"][0]["decision"]]
+                    decisions = scan["decisions"]
+                    decisions.sort(key=lambda x: parse(x["created"]))
 
-                    if scan["decisions"][0]["note"] != "":
-                        data["scan_note"] = scan["decisions"][0]["note"]
+                    data["decision"] = decisions[-1]["decision"]
+                    data["scan_note"] = ' / '.join([d["note"] for d in decisions])
 
                 df = pd.DataFrame.from_records([data], columns=dataframe_cols)
                 all_scans.append(df)

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -68,7 +68,7 @@ def convert_json_to_check_new_sessions_df(
                     decisions.sort(key=lambda x: parse(x["created"]))
 
                     data["decision"] = decisions[-1]["decision"]
-                    data["scan_note"] = ' / '.join([d["note"] for d in decisions])
+                    data["scan_note"] = '; '.join([f'{d["creator"]}: {d["note"]}' for d in decisions])
 
                 df = pd.DataFrame.from_records([data], columns=dataframe_cols)
                 all_scans.append(df)

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -62,7 +62,7 @@ def convert_json_to_check_new_sessions_df(
                     if scan["last_decision"]["note"] != "":
                         data["scan_note"] = scan["last_decision"]["note"]
 
-                if "decisions" in scan and scan["decisions"] is not None:
+                if "decisions" in scan and scan["decisions"] is not None and len(scan["decisions"]) > 0:
                     # TODO: what is the desired behavior here?
                     # Can we record multiple decisions to this data structure?
                     data["decision"] = MIQA2CNSDecisionCodes[scan["decisions"][0]["decision"]]

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -68,7 +68,7 @@ def convert_json_to_check_new_sessions_df(
                     decisions.sort(key=lambda x: parse(x["created"]))
 
                     data["decision"] = decisions[-1]["decision"]
-                    data["scan_note"] = '; '.join([f'{d["creator"]}: {d["note"]}' for d in decisions])
+                    data["scan_note"] = '; '.join([f'{d["creator"][:3]}: {d["note"]}' for d in decisions])
 
                 df = pd.DataFrame.from_records([data], columns=dataframe_cols)
                 all_scans.append(df)


### PR DESCRIPTION
There is one section where I am not sure of the desired behavior:
in the function `convert_json_to_check_new_sessions_df`, if the input json has a key "decisions" with multiple decision objects, how should these be recorded to the output dataframe? Currently, I record the first entry only. How is this data structure used and can it hold multiple decisions?