### PR TITLE
Fix formation of scan note from known and unknown data

### DIFF
--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -71,8 +71,11 @@ def convert_json_to_check_new_sessions_df(
                     data["decision"] = decisions[-1]["decision"]
                     data["scan_note"] = '; '.join(
                         [
-                            f'{d["creator"][:3] if d["creator"] else "ANON"}({d["created"] or "ND"}): {d["note"]}'
-                            if not re.findall(r"([A-Z])+\(([\d\/-]+)\):", d["note"]) else d["note"]
+                            f'{d["creator"][:3]}({d["created"]}): {d["note"]}'
+                            if (
+                                d['creator'] and d['created'] and
+                                not re.findall(r"([A-Z])+\(([\d\/-]+)\):", d["note"])
+                             ) else d["note"]
                             for d in decisions
                         ]
                     )

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -69,7 +69,13 @@ def convert_json_to_check_new_sessions_df(
                     decisions.sort(key=lambda x: parse(x["created"]) if x['created'] else datetime.datetime(1, 1, 1))
 
                     data["decision"] = decisions[-1]["decision"]
-                    data["scan_note"] = '; '.join([f'{d["creator"][:3]}: {d["note"]}' for d in decisions])
+                    data["scan_note"] = '; '.join(
+                        [
+                            f'{d["creator"][:3] if d["creator"] else "ANON"}({d["created"] or "ND"}): {d["note"]}'
+                            if not re.findall(r"([A-Z])+\(([\d\/-]+)\):", d["note"]) else d["note"]
+                            for d in decisions
+                        ]
+                    )
 
                 df = pd.DataFrame.from_records([data], columns=dataframe_cols)
                 all_scans.append(df)


### PR DESCRIPTION
This PR fixes the `TypeError: 'NoneType' object is not subscriptable` that the test suite was receiving when a decision object had null values for creator and date of creation.

For scan notes that match a certain regex for specifying creator and date of creation, like the one below, no changes are made to the scan note string.
`UF(2022-09-01): this person's T1/T2 white matter looks unusual (torn and falling apart)`

For other scan notes with no matches for that regex, known information is prepended to include the creator and date of creation. 
For example, a decision structured like this in the input file will have its note prepended with `ABC(12/10/2022):`
```
{
    "decision": "Q?",
    "creator": "ABC",
    "note": "this person's T1/T2 white matter looks unusual (torn and falling apart)",
    "created": "12/10/2022",
    "user_identified_artifacts": null,
    "location": null
}
```

If that information is unknown, no string will be prepended to the decision note.