### PR TITLE
Added help functionality to complete_csv2redcap_import

### DIFF
--- a/scripts/import/webcnp/complete_csv2redcap_import
+++ b/scripts/import/webcnp/complete_csv2redcap_import
@@ -7,7 +7,10 @@
 
 bindir=`dirname $0`
 csv_dir=${1}
-shift
+
+if [ "$csv_dir" != "-h" ]; then
+    shift
+fi
 
 # Read specific flags
 # original_args="$*"


### PR DESCRIPTION
Only shift the csv argument when the first argument passed is not the help flag. Not sure if this is the best approach for solving this problem.

Before: Had to force exit whenever only calling w/ -h because it was expecting first argument to be csv file name:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/import/webcnp (bug/complete_csv2redcap_help)$ ./complete_csv2redcap_import -h
^CTraceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 377, in _make_request
    httplib_response = conn.getresponse(buffering=True)
TypeError: getresponse() got an unexpected keyword argument 'buffering'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./update_summary_forms", line 77, in <module>
    rc_summary = session.connect_server('data_entry', True)
  File "/sibis-software/python-packages/sibispy/session.py", line 248, in connect_server
    connectionPtr = self.__connect_redcap_project__(api_type)
  File "/sibis-software/python-packages/sibispy/session.py", line 482, in __connect_redcap_project__
    data_entry = redcap.Project(
  File "/usr/local/lib/python3.8/site-packages/redcap/project.py", line 59, in __init__
    self.configure()
  File "/usr/local/lib/python3.8/site-packages/redcap/project.py", line 64, in configure
    self.metadata = self.__md()
  File "/usr/local/lib/python3.8/site-packages/redcap/project.py", line 104, in __md
    return self._call_api(p_l, "metadata")[0]
  File "/usr/local/lib/python3.8/site-packages/redcap/project.py", line 166, in _call_api
    return rcr.execute(**request_kwargs)
  File "/usr/local/lib/python3.8/site-packages/redcap/request.py", line 178, in execute
    response = self.session.post(self.url, data=self.payload, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 590, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/usr/local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 597, in urlopen
    httplib_response = self._make_request(conn, method, url,
  File "/usr/local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 380, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/local/lib/python3.8/http/client.py", line 1347, in getresponse
    response.begin()
  File "/usr/local/lib/python3.8/http/client.py", line 307, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.8/http/client.py", line 268, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.8/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
KeyboardInterrupt
```

Post Update: 
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/import/webcnp (bug/complete_csv2redcap_help)$ ./complete_csv2redcap_import -h
usage: update_summary_forms [-h] [-v] [--max-days-after-visit MAX_DAYS_AFTER_VISIT] [-a]
                            [--records-per-upload RECORDS_PER_UPLOAD] [-n NO_UPLOAD] [-p]
                            [-t TIME_LOG_DIR] [--study-id STUDY_ID] [--event EVENT]

Update WebCNP summary forms from imported data

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Verbose operation (default: False)
  --max-days-after-visit MAX_DAYS_AFTER_VISIT
                        Maximum number of days the scan session can be after the entered
                        'visit date' in REDCap to be assigned to a given event. (default:
                        120)
  -a, --update-all      Update all summary records, regardless of current completion status
                        (otherwise, only update records where cnp_datasetid is empty)
                        (default: False)
  --records-per-upload RECORDS_PER_UPLOAD
                        Maximum number of records to upload to REDCap using a single HTTP
                        request. This limits the request size and prevents upload problems.
                        (default: 30)
  -n NO_UPLOAD, --no-upload NO_UPLOAD
                        Do not upload any data to REDCap server; instead write to CSV file
                        with given path. (default: None)
  -p, --post-to-github  Post all issues to GitHub instead of std out. (default: False)
  -t TIME_LOG_DIR, --time-log-dir TIME_LOG_DIR
                        If set then time logs are written to that directory (default: None)
  --study-id STUDY_ID   Limit export by subject site id (e.g., 'X-12345-X-9'). (default:
                        None)
  --event EVENT         Limit export by event id (e.g., '8y_visit_arm_1') (default: None)
```