### PR TITLE
Added ability to force abbreviated lssaga youth format

### DIFF
--- a/scripts/redcap/update_bulk_forms
+++ b/scripts/redcap/update_bulk_forms
@@ -133,6 +133,19 @@ def process_form(form, complete_field_names, study_id, event):
 
         records[complete_field_names] = "2"
         return records[complete_field_names], previous[complete_field_names]
+    elif args.force_abbr_ssaga and form == "limesurvey_ssaga_youth":
+        # force lssaga_youth subform parts 2-4 to have empty status
+        # then set part 1 status and whole form status to complete
+        previous = records[complete_field_names]
+        for field in complete_field_names:
+            form_num = int(re.search(r'\d+', field).group())
+            if form_num == 1:
+                records[field] = 2
+            else:
+                records[field] = math.nan
+        records[form_complete_field] = 2
+        return records[complete_field_names], previous[complete_field_names]
+            
     else:
         # Unless we force complete update, drop already-Complete records for speed
         if not args.update_all:
@@ -240,6 +253,12 @@ parser.add_argument(
     help="Only process a specific event (e.g. baseline_visit_arm_1 or 1y_visit_arm_1)",
     action="store",
     default=None,
+)
+parser.add_argument(
+    "--force_abbr_ssaga",
+    help="Force ssaga subfrom parts 2-4 status to be Null for abbreviated lssaga youth forms",
+    action="store_true",
+    default=False,
 )
 
 


### PR DESCRIPTION
Ran for 7y after unlocking form and resolved error for subject A-00085-M-6:
https://ncanda.sri.com/redcap/redcap_v10.0.30/DataEntry/index.php?pid=20&id=A-00085-M-6&event_id=493&page=limesurvey_ssaga_youth

Example function call:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/redcap (master)$ ./update_bulk_forms -v -a --study-id A-00085-M-6 --event 7y_visit_arm_1 --force_abbr_ssaga --forms limesurvey_ssaga_youth
Processing bulk form limesurvey_ssaga_youth
Processing events ['7y_visit_arm_1']
Uploaded 1 records to REDCap.
```

Result of running update_visit_data after script ran:
```
ncanda@pipeline-back[pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/import/laptops$ ./update_visit_data -v --forms limesurvey_ssaga_part_2_youth --study-id A-00085-M-6
Processing the following forms:
	 limesurvey_ssaga_part_2_youth
Processing form lssaga2_youth / limesurvey_ssaga_part_2_youth
Record list from Import project: ['A-00085-M-6-2015-03-07', 'A-00085-M-6-2016-03-22', 'A-00085-M-6-2017-04-11']
Form ['limesurvey_ssaga_part_2_youth'] has 3 records in import project.
Processing ('A-00085-M-6', '4y_visit_arm_1')
Processing ('A-00085-M-6', '5y_visit_arm_1')
Processing ('A-00085-M-6', '6y_visit_arm_1')
Processing ('A-00085-M-6', '7y_visit_arm_1')
Processing ('A-00085-M-6', '8y_visit_arm_1')
Processing ('A-00085-M-6', '9y_visit_arm_1')
Uploaded 0 of 6 records to form limesurvey_ssaga_part_2_youth
```