### PR TITLE
Added catch for key error and error posting

### DIFF
--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -794,8 +794,32 @@ for redcap_event in redcap_project.events:
 
 # Have pipeline feeder check for "excluded" subjects that might have previously entered the pipeline
 if args.pipeline_root_dir:
-    excluded_subjects = mr_sessions_redcap[ mr_sessions_redcap.index.map( lambda key: subject_data['exclude'][key[0]] == 1 ) ]['mri_xnat_sid'].dropna().tolist()
-    mrpipeline.check_excluded_subjects( excluded_subjects, args.pipeline_root_dir )
+    try:
+        excluded_subjects = mr_sessions_redcap[ mr_sessions_redcap.index.map( lambda key: subject_data['exclude'][key[0]] == 1 ) ]['mri_xnat_sid'].dropna().tolist()
+    except KeyError as key_err:
+        bad_key = key_err.args[0]
+        err_row = mr_sessions_redcap.loc[(bad_key, slice(None)), :]
+        index_values = err_row.index.get_level_values('study_id').tolist()
+        index_values += err_row.index.get_level_values('redcap_event_name').tolist()
+        header = '-'.join(index_values)
+        slog.info(
+            header,
+            "Subject exists in REDCap that is not apart of Arm 1.",
+            info="There is a subject that exists in Redcap that is not apart of subject_data, currently \
+            identified cause of the discrepancy is a new subject has been created in an arm that doesn't \
+            also exist in arm 1.", 
+            site_resolution="1. Identify what the intended subject ID was. \n \
+            2. Input any information that was entered under the incorrect subject ID to the correct \
+            location. \n \
+            3. Once entered, post on this issue that the incorrectly created subject can be removed."
+        )
+        # drop the offending key error from the mr_sessions_redcap dataframe
+        mr_sessions_redcap = mr_sessions_redcap[mr_sessions_redcap.index.get_level_values('study_id') != bad_key]
+        if mr_sessions_redcap.empty:
+            excluded_subjects = None
+        else:
+            excluded_subjects = mr_sessions_redcap[ mr_sessions_redcap.index.map( lambda key: subject_data['exclude'][key[0]] == 1 ) ]['mri_xnat_sid'].dropna().tolist()
+            mrpipeline.check_excluded_subjects( excluded_subjects, args.pipeline_root_dir )
 
 # Filter out all records marked as "Complete", unless user instructed otherwise
 if not args.force_update:

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -804,8 +804,8 @@ if args.pipeline_root_dir:
         header = '-'.join(index_values)
         slog.info(
             header,
-            "Subject exists in REDCap that is not apart of Arm 1.",
-            info="There is a subject that exists in Redcap that is not apart of subject_data, currently \
+            "Subject exists in REDCap that does not exist in Arm 1.",
+            info="There is a subject that exists in Redcap that is not part of subject_data, currently \
             identified cause of the discrepancy is a new subject has been created in an arm that doesn't \
             also exist in arm 1.", 
             site_resolution="1. Identify what the intended subject ID was. \n \


### PR DESCRIPTION
Link to error that it generates: https://github.com/sibis-platform/ncanda-operations/issues/14550
Post update:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/redcap$ ./import_mr_sessions -v --pipeline-root-dir /fs/ncanda-share/cases --study-id E-00140-M-1 -p
Namespace(event=None, force_update=False, force_update_stroop=False, max_days_after_visit=120, missing_only=False, no_stroop=False, no_upload=False, pipeline_root_dir='/fs/ncanda-share/cases', post_to_github=True, run_pipeline_script=None, site=None, study_id='E-00140-M-1', time_log_dir=None, verbose=True)
================================
== Setting up posting to GitHub 
Setting up GitHub...
Parsing config: None
Using Personal Access Token to authenticate.
Connected to GitHub
... ready!
Found label: [Label(name="import_mr_sessions")]
== Posting to GitHub is ready 
================================
Posting E-00140-M-1-recovery_baseline_arm_2 Subject exists in REDCap that is not apart of Arm 1.
Checking for issue: E-00140-M-1-recovery_baseline_arm_2, Subject exists in REDCap that is not apart of Arm 1.
Issue does not exist.
Created issue... See: https://api.github.com/repos/sibis-platform/ncanda-operations/issues/14549
Warning: Nothing to import !
```

Pre update:
```
ncanda@pipeline-back[pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/redcap (master)$ ./import_mr_sessions --pipeline-root-dir /fs/ncanda-share/cases -v --study-id E-00140-M-1
Namespace(event=None, force_update=False, force_update_stroop=False, max_days_after_visit=120, missing_only=False, no_stroop=False, no_upload=False, pipeline_root_dir='/fs/ncanda-share/cases', post_to_github=False, run_pipeline_script=None, site=None, study_id='E-00140-M-1', time_log_dir=None, verbose=True)
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 2898, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1675, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1683, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'E-00140-M-1'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./import_mr_sessions", line 797, in <module>
    excluded_subjects = mr_sessions_redcap[ mr_sessions_redcap.index.map( lambda key: subject_data['exclude'][key[0]] == 1 ) ]['mri_xnat_sid'].dropna().tolist()
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 4797, in map
    new_values = super()._map_values(mapper, na_action=na_action)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/base.py", line 1160, in _map_values
    new_values = map_f(values, mapper)
  File "pandas/_libs/lib.pyx", line 2403, in pandas._libs.lib.map_infer
  File "./import_mr_sessions", line 797, in <lambda>
    excluded_subjects = mr_sessions_redcap[ mr_sessions_redcap.index.map( lambda key: subject_data['exclude'][key[0]] == 1 ) ]['mri_xnat_sid'].dropna().tolist()
  File "/usr/local/lib/python3.8/site-packages/pandas/core/series.py", line 882, in __getitem__
    return self._get_value(key)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/series.py", line 990, in _get_value
    loc = self.index.get_loc(label)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 2900, in get_loc
    raise KeyError(key) from err
KeyError: 'E-00140-M-1'
```
