### PR TITLE
Added logging to miqa_file_generation errors

### DIFF
--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1737,7 +1737,7 @@ if args.qc_json:
     rows_cols = [row.replace('\n', '').split(',') for row in scans_to_qc]
     df = pd.DataFrame(rows_cols[1:], columns=rows_cols[0])
     
-    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping,args)
+    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping)
     scans_to_qc_json_dict = miqa_file_generation.import_dataframe_to_dict(new_df)
     
     if miqa_file_generation.write_miqa_import_file(
@@ -1750,7 +1750,7 @@ if args.qc_json:
     rows_cols = [row.replace('\n', '').split(',') for row in scans_to_question]
     df = pd.DataFrame(rows_cols[1:], columns=rows_cols[0])
     
-    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping,args)
+    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping)
     scans_to_question_json_dict = miqa_file_generation.import_dataframe_to_dict(new_df)
 
     if miqa_file_generation.write_miqa_import_file(

--- a/scripts/xnat/check_new_sessions
+++ b/scripts/xnat/check_new_sessions
@@ -1737,7 +1737,7 @@ if args.qc_json:
     rows_cols = [row.replace('\n', '').split(',') for row in scans_to_qc]
     df = pd.DataFrame(rows_cols[1:], columns=rows_cols[0])
     
-    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping)
+    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping,args)
     scans_to_qc_json_dict = miqa_file_generation.import_dataframe_to_dict(new_df)
     
     if miqa_file_generation.write_miqa_import_file(
@@ -1750,7 +1750,7 @@ if args.qc_json:
     rows_cols = [row.replace('\n', '').split(',') for row in scans_to_question]
     df = pd.DataFrame(rows_cols[1:], columns=rows_cols[0])
     
-    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping)
+    new_df = miqa_file_generation.convert_dataframe_to_new_format(df,sibis_session,subject_mapping,args)
     scans_to_question_json_dict = miqa_file_generation.import_dataframe_to_dict(new_df)
 
     if miqa_file_generation.write_miqa_import_file(

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -5,6 +5,7 @@ import os
 import re
 import pathlib
 import pandas as pd
+from sibispy import sibislogger as slog
 from schema import Optional, Or, Schema, SchemaError, Use
 
 project_name_pattern = re.compile("([a-z]+)_incoming")
@@ -123,6 +124,7 @@ def convert_dataframe_to_new_format(
     df,
     session=None,
     subject_mapping=None,
+    args=None,
 ):
     new_rows = []
     for _index, row in df.iterrows():
@@ -158,9 +160,29 @@ def convert_dataframe_to_new_format(
             for location in scan_dir.glob("*.nii.gz")
         ]
         if len(frame_locations) == 0:
-            raise Exception(
-                f"Could not find any image files under {scan_dir}. Failed to write any frames for this scan."
+            # setup logging
+            slog.init_log(
+                args.verbose,
+                args.post_to_github,
+                "NCANDA XNAT",
+                "miqa_file_generation",
+                None, # no timing log
             )
+            pattern = r'/([A-Z]-\d+-[MF]-\d+-\d{8})/'
+            match = re.search(pattern, str(row['nifti_folder']))
+            if match:
+                subj_id = match.group(1)
+            else:
+                subj_id = row['xnat_experiment_id']
+            slog.info(
+                subj_id,
+                "Could not find any image files under scan dir.",
+                scan_dir=str(scan_dir),
+                scan_type=row['scan_type'],
+                eid=row['xnat_experiment_id'],
+                error="Failed to write any frames for this scan."
+            )
+            continue
 
         frame_locations.sort(key=lambda path: path.name)
         for index, frame_location in enumerate(frame_locations):

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -160,14 +160,6 @@ def convert_dataframe_to_new_format(
             for location in scan_dir.glob("*.nii.gz")
         ]
         if len(frame_locations) == 0:
-            # setup logging
-            slog.init_log(
-                args.verbose,
-                args.post_to_github,
-                "NCANDA XNAT",
-                "miqa_file_generation",
-                None, # no timing log
-            )
             pattern = r'/([A-Z]-\d+-[MF]-\d+-\d{8})/'
             match = re.search(pattern, str(row['nifti_folder']))
             if match:

--- a/scripts/xnat/miqa_file_generation.py
+++ b/scripts/xnat/miqa_file_generation.py
@@ -124,7 +124,6 @@ def convert_dataframe_to_new_format(
     df,
     session=None,
     subject_mapping=None,
-    args=None,
 ):
     new_rows = []
     for _index, row in df.iterrows():


### PR DESCRIPTION
Now includes logging when a scan upload issue causes json-qc output to fail.
example issue that is created:
https://github.com/sibis-platform/ncanda-operations/issues/14592