### PR TITLE
Changed overwriting of cnp_summary_complete when -a called

### DIFF
--- a/scripts/import/webcnp/update_summary_forms
+++ b/scripts/import/webcnp/update_summary_forms
@@ -149,7 +149,7 @@ for cnpvar in cnp_copy_variables:
     summary_records['cnp_%s' % cnpvar] = summary_records['cnp_%s' % cnpvar].map( str )
 
 # If we update all records, make sure to reset everything, so stuff can be made disappear in the summary, if it was removed from the imported project
-if args.update_all:
+if args.update_all or args.force:
     summary_records['cnp_datasetid'] = ''
 
     for cnpvar in cnp_copy_variables:
@@ -269,14 +269,15 @@ for key, row in summary_records.iterrows():
             
             try:
                 curr_summmary_complete = pandas.to_numeric(summary_records.at[key, 'cnp_summary_complete']).astype(int)
-                if args.update_all:
+                
+                if args.force:
+                    summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
+                elif args.update_all:
                     # only update summary complete score if new value is > old
                     if curr_summmary_complete < new_summary_complete:
                         summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
                     else:
                         summary_records.at[key, 'cnp_summary_complete'] = curr_summmary_complete
-                elif args.force:
-                    summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
                 else:
                     summary_records.at[key, 'cnp_summary_complete'] = curr_summmary_complete
             except:

--- a/scripts/import/webcnp/update_summary_forms
+++ b/scripts/import/webcnp/update_summary_forms
@@ -43,6 +43,7 @@ parser.add_argument( "-v", "--verbose", help="Verbose operation", action="store_
 parser.add_argument( "--max-days-after-visit", help="Maximum number of days the scan session can be after the entered 'visit date' in REDCap to be assigned to a given event.", action="store", default=120, type=int)
 parser.add_argument( "-a", "--update-all", help="Update all summary records, regardless of current completion status (otherwise, only update records where cnp_datasetid is empty)",
                      action="store_true")
+parser.add_argument( "-f", "--force", help="Force update up of everything from import, including overwriting summary score status (otherwise only max score between the two is used)", action="store_true")
 parser.add_argument( "--records-per-upload", help="Maximum number of records to upload to REDCap using a single HTTP request. This limits the request size and prevents upload problems.", action="store", default=30, type=int)
 parser.add_argument( "-n", "--no-upload", help="Do not upload any data to REDCap server; instead write to CSV file with given path.", action="store")
 parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
@@ -149,7 +150,6 @@ for cnpvar in cnp_copy_variables:
 
 # If we update all records, make sure to reset everything, so stuff can be made disappear in the summary, if it was removed from the imported project
 if args.update_all:
-    summary_records['cnp_summary_complete'] = ''
     summary_records['cnp_datasetid'] = ''
 
     for cnpvar in cnp_copy_variables:
@@ -258,16 +258,31 @@ for key, row in summary_records.iterrows():
 
             # Check completion status of the CNP instruments
             for [k,v] in cnp.instruments.items():
-                summary_complete = 1
+                new_summary_complete = 1
                 if cnp_data['%s_complete' % v] > 0:
                     column_name = 'cnp_instruments___%s' % k.replace('_','')
                     summary_records.at[key, column_name] = '1'
                 else:
                     column_name = 'cnp_instruments___%s' % k.replace('_','')
                     summary_records.at[key, column_name] = '0'
-                    summary_complete = 0
+                    new_summary_complete = 0
+            
+            try:
+                curr_summmary_complete = pandas.to_numeric(summary_records.at[key, 'cnp_summary_complete']).astype(int)
+                if args.update_all:
+                    # only update summary complete score if new value is > old
+                    if curr_summmary_complete < new_summary_complete:
+                        summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
+                    else:
+                        summary_records.at[key, 'cnp_summary_complete'] = curr_summmary_complete
+                elif args.force:
+                    summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
+                else:
+                    summary_records.at[key, 'cnp_summary_complete'] = curr_summmary_complete
+            except:
+                # if fails, then assume current summary complete status is blank
+                summary_records.at[key, 'cnp_summary_complete'] = new_summary_complete
 
-            summary_records.at[key, 'cnp_summary_complete'] = summary_complete
         elif summary_records['cnp_summary_complete'][key] != '' and float( summary_records['cnp_summary_complete'][key] ) > 0 and ( summary_records['cnp_missing'][key] != 1 ):
             error = ("WARNING: Previously assigned WebCNP data for subject {}, "
                      "event {} appears to have disappeared.").format(key[0], key[1])
@@ -345,18 +360,19 @@ else:
         print("Successfully uploaded %d/%d records to REDCap." % ( uploaded_count, len( summary_records ) ))
 
     # Update location and device as these are entered manually later 
-    update_record= imported_records.loc[summary_records_secondary['cnp_datasetid']]
-    summary_records_secondary['cnp_exam_location']=update_record['exam_location'].tolist()
-    summary_records_secondary['cnp_input_device']=update_record['input_device'].tolist()
-    summary_records_secondary= summary_records_secondary[['cnp_input_device','cnp_exam_location']]
-    summary_records_secondary=summary_records_secondary[summary_records_secondary['cnp_exam_location'] != '']
-    summary_records_secondary=summary_records_secondary[summary_records_secondary['cnp_input_device'] != '']
-    if len(summary_records_secondary):
-        if args.verbose:
-            print("Uploading records", summary_records_secondary)
-            
-        summary_records_secondary['cnp_exam_location'] = pandas.to_numeric(summary_records_secondary['cnp_exam_location']).astype('Int64')
-        summary_records_secondary['cnp_input_device'] = pandas.to_numeric(summary_records_secondary['cnp_input_device']).astype('Int64')
-        session.redcap_import_record(error_label, "", "", "UploadRecords",summary_records_secondary)
+    if summary_records_secondary:
+        update_record= imported_records.loc[summary_records_secondary['cnp_datasetid']]
+        summary_records_secondary['cnp_exam_location']=update_record['exam_location'].tolist()
+        summary_records_secondary['cnp_input_device']=update_record['input_device'].tolist()
+        summary_records_secondary= summary_records_secondary[['cnp_input_device','cnp_exam_location']]
+        summary_records_secondary=summary_records_secondary[summary_records_secondary['cnp_exam_location'] != '']
+        summary_records_secondary=summary_records_secondary[summary_records_secondary['cnp_input_device'] != '']
+        if len(summary_records_secondary):
+            if args.verbose:
+                print("Uploading records", summary_records_secondary)
+                
+            summary_records_secondary['cnp_exam_location'] = pandas.to_numeric(summary_records_secondary['cnp_exam_location']).astype(int)
+            summary_records_secondary['cnp_input_device'] = pandas.to_numeric(summary_records_secondary['cnp_input_device']).astype(int)
+            session.redcap_import_record(error_label, "", "", "UploadRecords",summary_records_secondary)
 
 slog.takeTimer1("script_time","{'records': " + str(len(summary_records)) + ", 'uploads': " +  str(uploaded_count) + "}")


### PR DESCRIPTION
When `update_summary_scores` was called with the `-a` flag, it would clear out the current data entry form complete variable, which means that for all past records it removes the complete status, and then tries to set it to 1. This causes a large amount of import errors.

Added a `-f` option that will allow for this behavior if desired.

Post fix:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/import/webcnp$ ./update_summary_forms -v -a --study-id D-00059-F-0
Dropping 79 records marked excluded in Imported from PennCNP
Uploading 5 records.
Uploading records 0 to 4
Successfully uploaded 1/5 records to REDCap.
```

Pre fix:
```
ncanda@pipeline-back[pipeline_back_1]:/sibis-software/ncanda-data-integration/scripts/import/webcnp$ ./update_summary_forms -v -a --study-id D-00059-F-0
Dropping 79 records marked excluded in Imported from PennCNP
Uploading 5 records.
Uploading records 0 to 4
{"experiment_site_id": "ImportToDataEntry-94bc92", "error": "session:redcap_import_record:Failed to import into REDCap", "requestError": "{'error': '\"D-00059-F-0\",\"cnp_summary_complete\",\"1\",\"This field is located on a form that is locked. You must first unlock this form for this record.\"\\n\"D-00059-F-0\",\"cnp_summary_complete\",\"1\",\"This field is located on a form that is locked. You must first unlock this form for this record.\"\\n\"D-00059-F-0\",\"cnp_summary_complete\",\"1\",\"This field is located on a form that is locked. You must first unlock this form for this record.\"\\n\"D-00059-F-0\",\"cnp_summary_complete\",\"1\",\"This field is located on a form that is locked. You must first unlock this form for this record.\"\\n\"D-00059-F-0\",\"cnp_summary_complete\",\"1\",\"This field is located on a form that is locked. You must first unlock this form for this record.\"'}", "red_api": "data_entry"}
Successfully uploaded 0/5 records to REDCap.
Traceback (most recent call last):
  File "./update_summary_forms", line 348, in <module>
    update_record= imported_records.loc[summary_records_secondary['cnp_datasetid']]
TypeError: list indices must be integers or slices, not str
```