### PR TITLE
Added skipped conversion to resolve #15649

### DIFF
--- a/scripts/import/webcnp/update_summary_forms
+++ b/scripts/import/webcnp/update_summary_forms
@@ -309,6 +309,9 @@ summary_records = summary_records[ summary_records['cnp_datasetid'] != '' ]
 # Drop all (logically) read-only columns from the summary data - these are the ones that are neither index-related (subject, event), nor part of the data imported from WebCNP
 summary_records = summary_records.drop( [ 'dob', 'exclude', 'visit_date' ], axis=1 )
 
+# Convert "Skipped" form status to incomplete ungraded data ("I")
+status_cols = [col for col in summary_records.columns if col.endswith('_status')]
+summary_records[status_cols] = summary_records[status_cols].replace("Skipped", "I")
 
 # Since redcap expects int values for this field
 summary_records['cnp_exam_location'] = pandas.to_numeric(summary_records['cnp_exam_location']).astype('Int64')


### PR DESCRIPTION
Added conversion from new CNP import values of "skipped" for form status to "I" for incomplete ungraded data to match old data dictionary

Post fix:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:~$ /sibis-software/ncanda-data-integration/scripts/import/webcnp/update_summary_forms -v --study-id B-00392-F-9
Dropping 115 records marked excluded in Imported from PennCNP
Uploading 1 records.
Uploading records 0 to 0
Successfully uploaded 1/1 records to REDCap.
```

Pre-fix:
```
ncanda@joe-pipeline-back[joe-pipeline_back_1]:~$ /sibis-software/ncanda-data-integration/scripts/import/webcnp/update_summary_forms -v --study-id B-00392-F-9
Dropping 115 records marked excluded in Imported from PennCNP
Uploading 1 records.
Uploading records 0 to 0
{"experiment_site_id": "B-00392-F-9_10y_visit_arm_1_ImportToDataEntry-c849ba", "error": "session:redcap_import_record:Failed to import into REDCap", "import_record_id": "None", "requestError": "{'error': '\"B-00392-F-9\",\"cnp_cpfd_status\",\"Skipped\",\"The value is not a valid category for cnp_cpfd_status\"\\n\"B-00392-F-9\",\"cnp_cpwd_status\",\"Skipped\",\"The value is not a valid category for cnp_cpwd_status\"\\n\"B-00392-F-9\",\"cnp_shortvolt_status\",\"Skipped\",\"The value is not a valid category for cnp_shortvolt_status\"\\n\"B-00392-F-9\",\"cnp_er40d_status\",\"Skipped\",\"The value is not a valid category for cnp_er40d_status\"\\n\"B-00392-F-9\",\"cnp_pcet_status\",\"Skipped\",\"The value is not a valid category for cnp_pcet_status\"\\n\"B-00392-F-9\",\"cnp_medf36_status\",\"Skipped\",\"The value is not a valid category for cnp_medf36_status\"\\n\"B-00392-F-9\",\"cnp_pvoc_status\",\"Skipped\",\"The value is not a valid category for cnp_pvoc_status\"\\n\"B-00392-F-9\",\"cnp_pvrt_status\",\"Skipped\",\"The value is not a valid category for cnp_pvrt_status\"\\n\"B-00392-F-9\",\"cnp_svdelay_status\",\"Skipped\",\"The value is not a valid category for cnp_svdelay_status\"'}", "red_api": "data_entry"}
Successfully uploaded 0/1 records to REDCap.
```