### PR TITLE
Validate presence of .txt and .edat E-Prime files while loading ALCPIC scans

### DIFF
--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -697,27 +697,36 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
     if 'alcpic' not in scans_by_type and 'mlalcpic' in scans_by_type:
         scans_by_type['alcpic'] = scans_by_type['mlalcpic']
 
+    # if alcpic scan is available for this session, import
     if 'alcpic' in scans_by_type:
         chosen_eid = scans_by_type['alcpic'][0]
         redcap_key_str = redcap_key[0] if isinstance(redcap_key, (list, tuple)) else redcap_key
-        result['mri_series_taskfmri_alcpic_eprime'] = get_alcpic_uris(
-            xnat_eid_list, redcap_key_str, xnat_pid, match_eid=chosen_eid
-        )
-        # Do not run import when there are no instance of eprime file
-        if not result['mri_series_taskfmri_alcpic_eprime']:
-            error = 'No Eprime files found for task-fMRI in XNAT.'
-            slog.info(
-                redcap_visit_id,
-                chosen_eid, 
-                error,
-                xnat_project_id=xnat_pid,
-                xnat_subject_id=xnat_sid,
-                subject_id=redcap_key_str,
-                error_description="There is no Eprime file found for the alcpic "
-                "task-fMRI in XNAT. There should be one .txt and one .edat2 eprime file.",
-                site_resolution="Please upload eprime files with the task-fMRI scan."
+        
+        # Retrieve all matching E-Prime URIs from XNAT
+        alcpic_uris = get_alcpic_uris(
+                xnat_eid_list, redcap_key_str, xnat_pid, match_eid=chosen_eid
             )
-            return [None,True]
+
+        # Validate that BOTH .txt and .edat files are present
+        found_txt = any(uri.endswith('.txt') for uri in alcpic_uris)
+        found_edat = any(uri.endswith(('.edat2', '.edat3')) for uri in alcpic_uris)
+
+        if not (found_txt and found_edat):
+            error_msg = (f"Missing one or more required E-Prime files for alcpic scan {chosen_eid}. "
+                         f"Found .txt: {found_txt}, Found .edatX: {found_edat}.")
+            
+            slog.info(redcap_visit_id, chosen_eid, error_msg, 
+                      xnat_project_id=xnat_pid, 
+                      xnat_subject_id=xnat_sid, 
+                      subject_id=redcap_key_str, 
+                      error_description="The session is missing E-PRIME file.",
+                      site_resolution="Please ensure both the .txt and the .edat2 files are uploaded to the E-PRIME resource.")
+            
+            # Stop the import
+            return [None, True]
+
+        # If validation passes, assign the URIs to the result dictionary
+        result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris
         result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
 
     for xnat_eid in xnat_eid_list:

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -699,11 +699,26 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
 
     if 'alcpic' in scans_by_type:
         chosen_eid = scans_by_type['alcpic'][0]
-        result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
         redcap_key_str = redcap_key[0] if isinstance(redcap_key, (list, tuple)) else redcap_key
         result['mri_series_taskfmri_alcpic_eprime'] = get_alcpic_uris(
             xnat_eid_list, redcap_key_str, xnat_pid, match_eid=chosen_eid
         )
+        # Do not run import when there are no instance of eprime file
+        if not result['mri_series_taskfmri_alcpic_eprime']:
+            error = 'No Eprime files found for task-fMRI in XNAT.'
+            slog.info(
+                redcap_visit_id,
+                chosen_eid, 
+                error,
+                xnat_project_id=xnat_pid,
+                xnat_subject_id=xnat_sid,
+                subject_id=redcap_key_str,
+                error_description="There is no Eprime file found for the alcpic "
+                "task-fMRI in XNAT. There should be one .txt and one .edat2 eprime file.",
+                site_resolution="Please upload eprime files with the task-fMRI scan."
+            )
+            return [None,True]
+        result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
 
     for xnat_eid in xnat_eid_list:
         result['mri_xnat_eids'] += xnat_eid + ' '

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -712,7 +712,12 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
         found_txt = any(uri.endswith('.txt') for uri in alcpic_uris_list)
         found_edat = any(uri.endswith(('.edat2', '.edat3')) for uri in alcpic_uris_list)
 
-        if not (found_txt and found_edat):
+        if found_txt and found_edat:
+            # If validation passes, assign the eprime and scan to the corresponding result dictionary
+            result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris
+            result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
+        else:
+            # If either or both of eprime files are missing
             error_msg = (f"Missing one or more required E-Prime files for alcpic scan {chosen_eid}. "
                          f"Found .txt: {found_txt}, Found .edatX: {found_edat}.")
             
@@ -722,10 +727,6 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
                       subject_id=redcap_key_str, 
                       error_description="The session is missing E-PRIME file.",
                       site_resolution="Please ensure both the .txt and the .edat files are uploaded to the E-PRIME resource.")
-        else:
-            # If validation passes, assign the eprime and scan to the corresponding result dictionary
-            result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris
-            result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
 
     for xnat_eid in xnat_eid_list:
         result['mri_xnat_eids'] += xnat_eid + ' '

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -706,10 +706,11 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
         alcpic_uris = get_alcpic_uris(
                 xnat_eid_list, redcap_key_str, xnat_pid, match_eid=chosen_eid
             )
+        alcpic_uris_list = alcpic_uris.split(' ')
 
         # Validate that BOTH .txt and .edat files are present
-        found_txt = any(uri.endswith('.txt') for uri in alcpic_uris)
-        found_edat = any(uri.endswith(('.edat2', '.edat3')) for uri in alcpic_uris)
+        found_txt = any(uri.endswith('.txt') for uri in alcpic_uris_list)
+        found_edat = any(uri.endswith(('.edat2', '.edat3')) for uri in alcpic_uris_list)
 
         if not (found_txt and found_edat):
             error_msg = (f"Missing one or more required E-Prime files for alcpic scan {chosen_eid}. "
@@ -721,9 +722,6 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
                       subject_id=redcap_key_str, 
                       error_description="The session is missing E-PRIME file.",
                       site_resolution="Please ensure both the .txt and the .edat files are uploaded to the E-PRIME resource.")
-            
-            # Stop the import
-            return [None, True]
 
         # If validation passes, assign the URIs to the result dictionary
         result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -722,10 +722,10 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
                       subject_id=redcap_key_str, 
                       error_description="The session is missing E-PRIME file.",
                       site_resolution="Please ensure both the .txt and the .edat files are uploaded to the E-PRIME resource.")
-
-        # If validation passes, assign the URIs to the result dictionary
-        result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris
-        result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
+        else:
+            # If validation passes, assign the eprime and scan to the corresponding result dictionary
+            result['mri_series_taskfmri_alcpic_eprime'] = alcpic_uris
+            result['mri_series_taskfmri_alcpic_scan'] = encode_session_and_scan(scans_by_type, ['alcpic'])
 
     for xnat_eid in xnat_eid_list:
         result['mri_xnat_eids'] += xnat_eid + ' '

--- a/scripts/redcap/import_mr_sessions
+++ b/scripts/redcap/import_mr_sessions
@@ -697,7 +697,7 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
     if 'alcpic' not in scans_by_type and 'mlalcpic' in scans_by_type:
         scans_by_type['alcpic'] = scans_by_type['mlalcpic']
 
-    # if alcpic scan is available for this session, import
+    # if alcpic scan and corresponding e-prime files are available for this session, import them
     if 'alcpic' in scans_by_type:
         chosen_eid = scans_by_type['alcpic'][0]
         redcap_key_str = redcap_key[0] if isinstance(redcap_key, (list, tuple)) else redcap_key
@@ -720,7 +720,7 @@ def get_xnat_data(session,red2cas, redcap_key, xnat, xnat_sid, xnat_pid, pipe_id
                       xnat_subject_id=xnat_sid, 
                       subject_id=redcap_key_str, 
                       error_description="The session is missing E-PRIME file.",
-                      site_resolution="Please ensure both the .txt and the .edat2 files are uploaded to the E-PRIME resource.")
+                      site_resolution="Please ensure both the .txt and the .edat files are uploaded to the E-PRIME resource.")
             
             # Stop the import
             return [None, True]


### PR DESCRIPTION

The primary difference between the versions is how they handle incomplete E-prime data. The original Code would import empty/partial E-prime data and fmri scan without warning. The updated Code validates the files first. When we have a alcpic frmi, both .txt and .edat2/.edat3 files need to be presence as well. If any of eprime is missing, it logs an error and **skips** the alcpic fmri section without loading the scan and E-prime, while allowing the rest of the session import (e.g. T1, T2, etc) to continue.

### Testing examples

To demonstrate how this unit code handles different scenarios, here is the expected behavior for three different subjects:

#### 1. Subject `A-00001-F-2` (Complete Data)

*Scenario: Subject has the fMRI scan and both required E-Prime files (`.txt` and `.edat`).*

* **Original Code:**
  * Identifies the `alcpic` scan.
  * The scan is assigned to `result['mri_series_taskfmri_alcpic_scan']` .
  * Calls `get_alcpic_uris`, which returns both E-Prime paths.
  * The E-Prime file is assigned to `result['mri_series_taskfmri_alcpic_eprime']` .
  * **Result:** **Success.**


* **Updated Code:**
  * Identifies the `alcpic` scan.
  * Retrieves URIs and evaluates `found_txt=True` and `found_edat=True`.
  * The condition `if found_txt and found_edat:` passes.
  * Scan and E-Prime files are assigned to `result['mri_series_taskfmri_alcpic_scan']` and `result['mri_series_taskfmri_alcpic_eprime']` .
  * **Result:** **Success.** 



#### 2. Subject `B-00102-M-1` (Incomplete Data)

*Scenario: Subject has the fMRI scan but the `.edat` file is missing (only `.txt` exists).*

* **Original Code:**
  * Identifies the `alcpic` scan.
  * The scan is assigned to `result['mri_series_taskfmri_alcpic_scan']`.
  * `get_alcpic_uris` returns only the `.txt` path.
  * The E-Prime file is assigned to `result['mri_series_taskfmri_alcpic_eprime']` .
  * **Result:** **Silent Partial Success.** Incomplete data is entered into REDCap, no error is raised.


* **Updated Code:**
  * Identifies the `alcpic` scan.
  * Evaluates `found_txt=True` but `found_edat=False`.
  * Logic enters the `else:` block.
  * `slog.info` logs: *"Missing one or more required E-Prime files... Found .edatX: False."*
  * **Result:** **Skipped.** The `result['mri_series_taskfmri_alcpic_scan']` and `result['mri_series_taskfmri_alcpic_eprime']` are left as **empty string**, but the rest of the subject's session (e.g., T1, T2 scans) continues to import. Site is alarmed that E-prime is missing.



#### 3. Subject `E-00490-F-2` (No E-Prime Data)

*Scenario: Subject has the fMRI scan but NO E-Prime files were uploaded to XNAT.*

* **Original Code:**
  * Identifies the `alcpic` scan.
  * The scan is assigned to `result['mri_series_taskfmri_alcpic_scan']`.
  * `get_alcpic_uris` returns an empty string.
  * Saves the scan to REDCap but leaves the E-Prime field empty.
  * **Result:** **Silent Partial Success.** Incomplete data is entered into REDCap, no error is raised.


* **Updated Code:**
  * Identifies the `alcpic` scan.
  * Evaluates `found_txt=False` and `found_edat=False`.
  * Logic enters the `else:` block.
  * `slog.info` logs: *"Found .txt: False, Found .edatX: False."*
  * **Result:** **Skipped.** The `result['mri_series_taskfmri_alcpic_scan']` and `result['mri_series_taskfmri_alcpic_eprime']` are left as **empty string**, but the rest of the subject's session (e.g., T1, T2 scans) continues to import. Site is alarmed that E-prime is missing.
